### PR TITLE
add isPublication attribute to link

### DIFF
--- a/Model/lib/xml/tuningManager/apiTuningManager.xml
+++ b/Model/lib/xml/tuningManager/apiTuningManager.xml
@@ -7091,6 +7091,7 @@ select h.dataset_link_id, h.dataset_presenter_id, h.description
                                             , 'DEFAULT_DATASET_NAME', macros.name) 
                                             , 'DEFAULT_DATASET_PRESENTER_NAME', macros.dataset_presenter_name) 
                                             , 'DEFAULT_ORGANISM_PK', macros.org_pk) as url
+     , h.isPublication
 from datasetpresenter dsp, macros, datasethyperlink h
 where macros.dataset_presenter_id = dsp.dataset_presenter_id
 and h.dataset_presenter_id = macros.dataset_presenter_id


### PR DESCRIPTION
With EbrcModelCommon PR [#11](https://github.com/VEuPathDB/EbrcModelCommon/pull/11) and ApiCommonPresenters PR [#1](https://github.com/VEuPathDB/ApiCommonPresenters/pull/1) , addresses redmine #46442

Adds isPublication as attribute of link element.