### PR TITLE
Add match sequence

### DIFF
--- a/Model/lib/xml/tuningManager/apiTuningManager.xml
+++ b/Model/lib/xml/tuningManager/apiTuningManager.xml
@@ -510,6 +510,7 @@ and tp.ec_number_gene like replace(pn.display_label, '-', '%')
     <externalDependency name="dots.domainfeature"/>
     <externalDependency name="dots.dbrefaafeature"/>
     <externalDependency name="dots.aalocation"/>
+    <externalDependency name="dots.translatedaasequence"/>
     <ancillaryTable name="InterproDomainDatabase"/>
     <ancillaryTable name="InterproDomainAccession"/>
     <sql>
@@ -533,6 +534,7 @@ and tp.ec_number_gene like replace(pn.display_label, '-', '%')
             ELSE TO_CHAR(df.e_value, '9.9EEEE')
           END AS interpro_e_value
         , df2.source_id AS interpro_family_id
+        , dbms_lob.substr(tas.sequence, least(al.end_min - al.start_min + 1, 4000) , al.start_min) as match_sequence
         FROM
           TranscriptAttributes ta
         , dots.AaLocation al
@@ -544,8 +546,10 @@ and tp.ec_number_gene like replace(pn.display_label, '-', '%')
         , dots.DbRefAaFeature draf
         , dots.DomainFeature df
         , dots.DomainFeature df2
+        , dots.TranslatedAASequence tas
         WHERE xd3.name IN('InterproscanData_RSRC', 'INTERPRO', 'Prints', 'HAMAP', 'SFLD', 'TIGRFAM', 'SUPERFAMILY', 'Pfam', 'PIRSF', 'PROSITE patterns', 'Superfamily', 'PRINTS', 'InterProScan', 'PFAM', 'SMART', 'CDD', 'PANTHER')
           AND ta.aa_sequence_id = df.aa_sequence_id
+          AND ta.aa_sequence_id = tas.aa_sequence.id
           AND (ta.taxon_id = '&filterValue' or nvl('&filterValue', 0) = 0)
           AND df.aa_feature_id = draf.aa_feature_id
           AND df.aa_feature_id = al.aa_feature_id


### PR DESCRIPTION
Redmine 3059

Tested by pasting the sequence of PfNF166_080020400 into interproscan, and having its annotation for cd00009 match table content, i.e.
```
IGRDNEIRRAIQILSRRTKNNPILLGDPGVGKTAIVEGLAIKIVQGDVPDSLKGRKLVSLDMSSLIAGAKYRGDFEERLK
SILKEVQDAEGQVVMFIDEIHTVVGAGAVAEGALDAGNILKPMLARGELRCIGATTVSEYRQFIEKDKALERRFQQILVE
QP
```

