### PR TITLE
No .bed for dynspans and ESTs

### DIFF
--- a/Model/lib/wdk/model/records/dynSpanRecord.xml
+++ b/Model/lib/wdk/model/records/dynSpanRecord.xml
@@ -32,9 +32,6 @@
       <reporter name="tableTabular" displayName="%%tableReporterDisplayName%%" scopes="results"
                 implementation="org.gusdb.wdk.model.report.reporter.TableTabularReporter" />
 
-      <reporter name="bed" displayName="(SRT-NEW!) BED - coordinates of sequences, configurable" scopes="results, record"
-                implementation="org.apidb.apicommon.model.report.bed.BedDynSpanReporter" />
-
       <reporter name="sequence" displayName="(SRT-NEW!) FASTA - sequence retrieval, configurable" scopes="results, record"
                 implementation="org.apidb.apicommon.model.report.sequence.SequenceReporter" />
 

--- a/Model/lib/wdk/model/records/estRecords.xml
+++ b/Model/lib/wdk/model/records/estRecords.xml
@@ -94,9 +94,6 @@
       <reporter name="tableTabular" displayName="%%tableReporterDisplayName%%" scopes="results" excludeProjects="EuPathDB" 
                 implementation="org.gusdb.wdk.model.report.reporter.TableTabularReporter" />
 
-      <reporter name="bed" displayName="(SRT-NEW!) BED - coordinates of sequences, configurable" scopes="results, record"
-                implementation="org.apidb.apicommon.model.report.bed.BedEstReporter" />
-
       <reporter name="sequence" displayName="(SRT-NEW!) FASTA - sequence retrieval, configurable" scopes="results, record"
                 implementation="org.apidb.apicommon.model.report.sequence.SequenceReporter" />
 


### PR DESCRIPTION
Totally agreeing with Susanne that these options are not meaningful for the user. It was good for testing, but now we don't need it.