### PR TITLE
Update geneQueries.xml

### DIFF
--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1788,7 +1788,6 @@ AND 1=0
               SELECT distinct gs.transcript_source_id AS source_id, gs.gene_source_id, ta.project_id,
                     'Y' as matched_result,
                     apidb.tab_to_string(set(cast(COLLECT(distinct gs.evidence_code) AS apidb.varchartab)), ', ') as evidence_code,
---                  listagg(gs.is_go_slim, ',')WITHIN GROUP (ORDER BY gs.is_go_slim) as is_go_slim
                     regexp_replace(apidb.tab_to_string(set(cast(COLLECT(distinct to_char(gs.is_go_slim)) AS apidb.varchartab)), ', '),
                                      ', $', '')
                       as is_go_slim
@@ -1796,14 +1795,14 @@ AND 1=0
               WHERE ta.taxon_id IN ($$organism$$)
                 AND ta.aa_sequence_id = gs.aa_sequence_id
                 AND decode(gs.evidence_code, 'IEA', 'Computed', 'Curated') in ($$go_term_evidence$$)
---              and case when $$go_term_slim$$ = 'Yes' and gs.is_go_slim = '1' then 1 
---                       when ($$go_term_slim$$ = 'No' and (gs.is_go_slim = '1' or gs.is_go_slim = '0')) then 1 
---                       else 0
- --                 end = 1 
-                AND (gs.go_id IN ($$go_typeahead$$)
-                     OR (lower(gs.go_term_name) like lower(REPLACE($$go_term$$, '*', '%'))
-                     OR lower( gs.go_id) like lower(REPLACE($$go_term$$, '*', '%'))
-                     OR lower(gs.go_id || ' : ' || gs.go_term_name) like lower(REPLACE($$go_term$$, '*', '%'))) )
+                AND (
+                  gs.go_id IN ($$go_typeahead$$) OR (
+                    $$go_term$$ != 'N/A' AND (               
+                      lower(gs.go_term_name) like lower(REPLACE($$go_term$$, '*', '%')) OR
+                      gs.go_id = upper($$go_term$$)
+                    )
+                  )
+                )
               GROUP BY gs.transcript_source_id, gs.gene_source_id, ta.project_id
               ORDER BY gs.transcript_source_id
            ]]>


### PR DESCRIPTION
speed up GoTerm query (it was slow in the context of many organisms):
1. only execute wildcard search if user has supplied a free text term (rather than using the vocabulary, which is common case)
2. lose the wildcard clause that allows users to supply GO ID mashed together with the go term (why would they do that?).  just extra work.