### PR TITLE
Open pathway map in new tab

### DIFF
--- a/Model/lib/wdk/model/questions/pathwayQuestions.xml
+++ b/Model/lib/wdk/model/questions/pathwayQuestions.xml
@@ -217,7 +217,7 @@
                         inReportMaker="false" truncateTo="100000" sortable="false" align="center">
                 <text>
                    <![CDATA[
-                   <a target="PathwayMap-$$source_id$$" data-name="pathway_map" href="@WEBAPP_BASE_URL@/record/pathway/$$source$$/$$source_id$$?geneStepId=$$gene_result$$&exclude_incomplete_ec=$$exclude_incomplete_ec$$&exact_match_only=$$exact_match_only$$">$$source_id$$ (decorated)</a>
+                   <a target="_blank" data-name="pathway_map" href="@WEBAPP_BASE_URL@/record/pathway/$$source$$/$$source_id$$?geneStepId=$$gene_result$$&exclude_incomplete_ec=$$exclude_incomplete_ec$$&exact_match_only=$$exact_match_only$$">$$source_id$$ (decorated)</a>
                     ]]>
                 </text>
               </textAttribute>
@@ -262,7 +262,7 @@
                         inReportMaker="false" truncateTo="100000" sortable="false" align="center">
                 <text>
                    <![CDATA[
-                   <a target="PathwayMap-$$source_id$$"
+                   <a target="_blank"
                      data-name="pathway_map"
                      href="@WEBAPP_BASE_URL@/record/pathway/$$source$$/$$source_id$$?node_list=$$compounds$$">$$source_id$$ (decorated)</a>
                     ]]>

--- a/Model/lib/wdk/model/questions/pathwayQuestions.xml
+++ b/Model/lib/wdk/model/questions/pathwayQuestions.xml
@@ -213,11 +213,11 @@
               <columnAttribute name="exclude_incomplete_ec" displayName="exclude_incomplete_ec param value" internal="true"/>
               <columnAttribute name="exact_match_only" displayName="exact_match_only param value" internal="true"/>
 
-              <textAttribute name="pathwayMap" displayName="Map - Painted With Transformed Genes (new window)" excludeProjects="EuPathDB"
+              <textAttribute name="pathwayMap" displayName="Map - Painted With Transformed Genes (new tab)" excludeProjects="EuPathDB"
                         inReportMaker="false" truncateTo="100000" sortable="false" align="center">
                 <text>
                    <![CDATA[
-                   <a class="new-window" data-name="pathway_map" href="@WEBAPP_BASE_URL@/record/pathway/$$source$$/$$source_id$$?geneStepId=$$gene_result$$&exclude_incomplete_ec=$$exclude_incomplete_ec$$&exact_match_only=$$exact_match_only$$">$$source_id$$ (decorated)</a>
+                   <a target="PathwayMap-$$source_id$$" data-name="pathway_map" href="@WEBAPP_BASE_URL@/record/pathway/$$source$$/$$source_id$$?geneStepId=$$gene_result$$&exclude_incomplete_ec=$$exclude_incomplete_ec$$&exact_match_only=$$exact_match_only$$">$$source_id$$ (decorated)</a>
                     ]]>
                 </text>
               </textAttribute>
@@ -258,11 +258,11 @@
                   <property name="type">int</property>
                 </reporter>
           </columnAttribute>
-             <textAttribute name="pathwayMap" displayName="Map - Painted With Transformed Compounds (new window)" excludeProjects="EuPathDB"
+             <textAttribute name="pathwayMap" displayName="Map - Painted With Transformed Compounds (new tab)" excludeProjects="EuPathDB"
                         inReportMaker="false" truncateTo="100000" sortable="false" align="center">
                 <text>
                    <![CDATA[
-                   <a class="new-window"
+                   <a target="PathwayMap-$$source_id$$"
                      data-name="pathway_map"
                      href="@WEBAPP_BASE_URL@/record/pathway/$$source$$/$$source_id$$?node_list=$$compounds$$">$$source_id$$ (decorated)</a>
                     ]]>


### PR DESCRIPTION
Resolves part 1 of [this redmine issue](https://redmine.apidb.org/issues/45026). Currently, the column header says the link will open in a new window, which is not the case. I changed the verbiage to indicate it'll open in a new tab (since many browsers block popups), and I changed the model to actually open the link in a new tab.