### PR TITLE
Update formatting for ismTypes visibleHelp

### DIFF
--- a/Model/lib/wdk/model/questions/params/geneParams.xml
+++ b/Model/lib/wdk/model/questions/params/geneParams.xml
@@ -1005,14 +1005,30 @@
           </help>
 
         <visibleHelp><![CDATA[
-            Transcript Novelty describes how the TALON prediction differs from known gene models<br/><br/>
-            Genomic: Prediction has no overlapping splice junctions compared to known models<br/><br/>
-            Intergenic: Prediction lacks any overlap with any known model<br/><br/>
-            Incomplete Splice Match (ISM): Prediction matches a subsection of a known gene model but has a novel putative start or end point. Further categorised into mismatches at the 5' end (prefix), 3' end (suffix) or both<br/><br/>
-            Known: Prediction exactly matches a known model<br/><br/>
-            Novel In Collection (NIC): Prediction uses known splice donors or acceptors but reveals new connections (e.g., skipped exon isoforms)<br/><br/>
-            Novel Not In Collection (NNC): Prediction  has at least one novel splice donor or acceptor<br/><br/>
-            Antisense: Prediction overlaps a known model, but is oriented in the opposite direction
+            Transcript Novelty describes how the TALON prediction differs from known gene models:
+            
+            <dl>
+              <dt>Genomic:</dt>
+              <dd>Prediction has no overlapping splice junctions compared to known models</dd>
+
+              <dt>Intergenic:</dt>
+              <dd>Prediction lacks any overlap with any known model</dd>
+
+              <dt>Incomplete Splice Match (ISM):</dt>
+              <dd>Prediction matches a subsection of a known gene model but has a novel putative start or end point. Further categorised into mismatches at the 5' end (prefix), 3' end (suffix) or both</dd>
+
+              <dt>Known:</dt>
+              <dd>Prediction exactly matches a known model</dd>
+
+              <dt>Novel In Collection (NIC):</dt>
+              <dd>Prediction uses known splice donors or acceptors but reveals new connections (e.g., skipped exon isoforms)</dd>
+
+              <dt>Novel Not In Collection (NNC):</dt>
+              <dd>Prediction  has at least one novel splice donor or acceptor</dd>
+
+              <dt>Antisense:</dt>
+              <dd>Prediction overlaps a known model, but is oriented in the opposite direction</dd>
+            </dl>
         ]]>
         </visibleHelp>
 


### PR DESCRIPTION
This PR updates the markup for the visible help for the `ismTypes_span` param, using semantic tags, and to support styling changes in https://github.com/VEuPathDB/web-monorepo/pull/583