### PR TITLE
Long read count param

### DIFF
--- a/Model/lib/dst/longReadRnaSeq.dst
+++ b/Model/lib/dst/longReadRnaSeq.dst
@@ -15,7 +15,7 @@ prop=includeProjects
 
         <paramRef ref="geneParams.long_read_datasets" default="${datasetName}" visible="false"/>
         <paramRef ref="geneParams.ismTypes"/>
-        <paramRef ref="SpanParams.transcript_length"/>
+        <paramRef ref="sharedParams.transcript_length"/>
 
          <attributesList 
               summary="source_id,gene_source_id,num_new_models,transcript_novelty,incomplete_splice_match_type,tfbs_gbrowse"

--- a/Model/lib/dst/longReadRnaSeq.dst
+++ b/Model/lib/dst/longReadRnaSeq.dst
@@ -15,6 +15,7 @@ prop=includeProjects
 
         <paramRef ref="geneParams.long_read_datasets" default="${datasetName}" visible="false"/>
         <paramRef ref="geneParams.ismTypes"/>
+        <paramRef ref="sharedParams.supporting_read_count"/>
         <paramRef ref="sharedParams.transcript_length"/>
 
          <attributesList 

--- a/Model/lib/dst/longReadRnaSeqSpan.dst
+++ b/Model/lib/dst/longReadRnaSeqSpan.dst
@@ -15,7 +15,7 @@ prop=includeProjects
 
         <paramRef ref="geneParams.long_read_datasets" default="${datasetName}" visible="false"/>
         <paramRef ref="geneParams.ismTypes_span"/>
-	    <paramRef ref="SpanParams.transcript_length"/>
+	    <paramRef ref="sharedParams.transcript_length"/>
 
          <attributesList 
               summary="organism,transcript_novelty,tfbs_gbrowse"

--- a/Model/lib/dst/longReadRnaSeqSpan.dst
+++ b/Model/lib/dst/longReadRnaSeqSpan.dst
@@ -19,7 +19,7 @@ prop=includeProjects
 	    <paramRef ref="sharedParams.transcript_length"/>
 
          <attributesList 
-              summary="organism,transcript_novelty,tfbs_gbrowse"
+              summary="organism,transcript_novelty,total_count,tfbs_gbrowse"
         />
 	 
 	<summary><![CDATA[
@@ -34,13 +34,13 @@ prop=includeProjects
 
 
      <dynamicAttributes>
-           <columnAttribute name="contextStart" internal="true"/>
-           <columnAttribute name="contextEnd" internal="true"/>
-           <columnAttribute name="dataset_name" internal="true"/>
-           <columnAttribute name="internal_abbrev" internal="true"/>
-           <columnAttribute name="chr_source_id" internal="true"/>
-           <columnAttribute name="min_start" internal="true"/>
-           <columnAttribute name="max_end" internal="true"/>
+            <columnAttribute name="contextStart" internal="true"/>
+            <columnAttribute name="contextEnd" internal="true"/>
+            <columnAttribute name="dataset_name" internal="true"/>
+            <columnAttribute name="internal_abbrev" internal="true"/>
+            <columnAttribute name="chr_source_id" internal="true"/>
+            <columnAttribute name="min_start" internal="true"/>
+            <columnAttribute name="max_end" internal="true"/>
           
            <columnAttribute name="transcript_novelty" displayName="Transcript Novelty"
             help="Describes how the TALON prediction differs from the gene model;                                                                                      
@@ -52,6 +52,12 @@ prop=includeProjects
             Known: Prediction exactly matches a known model;
             Antisense: Prediction overlaps an existing model but is oriented in the opposite direction" align="center"/>
 
+            <columnAttribute name="total_count" displayName="Supporting Reads">
+                <reporter name="histogram" displayName="Histogram" scopes="" implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">
+                    <description>Display the histogram of the values of this attribute</description>
+                    <property name="type">int</property>
+                </reporter>
+           </columnAttribute>
 
         <textAttribute name="tfbs_gbrowse" displayName="JBrowseLongRead" excludeProjects="EuPathDB"
                           inReportMaker="false" truncateTo="100000" help="JBrowse view including TALON predictions from the selected dataset. The selected region is highlighted.">

--- a/Model/lib/dst/longReadRnaSeqSpan.dst
+++ b/Model/lib/dst/longReadRnaSeqSpan.dst
@@ -15,6 +15,7 @@ prop=includeProjects
 
         <paramRef ref="geneParams.long_read_datasets" default="${datasetName}" visible="false"/>
         <paramRef ref="geneParams.ismTypes_span"/>
+        <paramRef ref="sharedParams.supporting_read_count"/>
 	    <paramRef ref="sharedParams.transcript_length"/>
 
          <attributesList 

--- a/Model/lib/wdk/model/questions/params/sharedParams.xml
+++ b/Model/lib/wdk/model/questions/params/sharedParams.xml
@@ -1721,6 +1721,13 @@ This parameter allows you to apply the minimum number of peptides to each select
       </help>
     </flatVocabParam>
 
+   <stringParam name="transcript_length"
+        prompt="Minimum transcript length" number="true">
+        <help> Enter the minimum length of TALON transcript to be returned</help>
+        <suggest default="20"/>
+   </stringParam>
+
+
   </paramSet>
 
 

--- a/Model/lib/wdk/model/questions/params/sharedParams.xml
+++ b/Model/lib/wdk/model/questions/params/sharedParams.xml
@@ -1723,9 +1723,15 @@ This parameter allows you to apply the minimum number of peptides to each select
 
    <stringParam name="transcript_length"
         prompt="Minimum transcript length" number="true">
-        <help> Enter the minimum length of TALON transcript to be returned</help>
+        <help> Enter the minimum length for a TALON prediction</help>
         <suggest default="20"/>
    </stringParam>
+
+    <stringParam name="supporting_read_count"
+        prompt="Minimum number of supporting reads" number="true">
+        <help>Enter the minimum number of reads that must support a TALON prediction</help>
+        <suggest default="20"/>
+    </stringParam>
 
 
   </paramSet>

--- a/Model/lib/wdk/model/questions/params/sharedParams.xml
+++ b/Model/lib/wdk/model/questions/params/sharedParams.xml
@@ -1730,7 +1730,7 @@ This parameter allows you to apply the minimum number of peptides to each select
     <stringParam name="supporting_read_count"
         prompt="Minimum number of supporting reads" number="true">
         <help>Enter the minimum number of reads that must support a TALON prediction</help>
-        <suggest default="20"/>
+        <suggest default="10"/>
     </stringParam>
 
 

--- a/Model/lib/wdk/model/questions/params/spanParams.xml
+++ b/Model/lib/wdk/model/questions/params/spanParams.xml
@@ -354,14 +354,6 @@
           </enumList>   
     </enumParam>
 
-   <stringParam name="transcript_length"
-                      prompt="Minimum transcript length"
-                      number="true">
-             <help> Enter the minimum length of TALON transcript to be returned</help>
-
-             <suggest default="20"/>
-   </stringParam>
-
 
     <enumParam name="sequence_strand_ij" 
                                         prompt="Select strand"

--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1011,6 +1011,7 @@ FROM
    <sqlQuery name="GenesByISM" includeProjects="PlasmoDB,ToxoDB" >
 	    <paramRef ref="geneParams.long_read_datasets"/>
         <paramRef ref="geneParams.ismTypes"/>
+        <paramRef ref="sharedParams.supporting_read_count"/>
 	    <paramRef ref="sharedParams.transcript_length"/>
         <column name="project_id"/>
         <column name="source_id"/>
@@ -1081,6 +1082,7 @@ FROM
              processName="org.apidb.apicomplexa.wsfplugin.apifed.ApiFedPlugin">
 	    <paramRef ref="geneParams.long_read_datasets"/>
         <paramRef ref="geneParams.ismTypes"/>
+        <paramRef ref="sharedParams.supporting_read_count"/>
         <paramRef ref="sharedParams.transcript_length"/>
         <wsColumn name="source_id" width="50" wsName="source_id"/>
         <wsColumn name="gene_source_id" width="50" wsName="gene_source_id"/>

--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1031,8 +1031,7 @@ FROM
         <sql>
 
 
-	select
-        source_id
+	    select distinct source_id
         , gene_source_id
         , count(source_id) as num_new_models
         , min(transcript_length) as min_new_transcript_length
@@ -1041,37 +1040,48 @@ FROM
         , listagg(distinct transcript_novelty, ', ') within group (order by transcript_novelty) as transcript_novelty
         , listagg(distinct incomplete_splice_match_type, ', ') within group (order by incomplete_splice_match_type) as incomplete_splice_match_type
         , min(min_start) as min_start
-	, min(min_start) - 1000 as contextStart
+	    , min(min_start) - 1000 as contextStart
         , max(max_end) as max_end
-	, max(max_end) + 1000 contextEnd
+	    , max(max_end) + 1000 contextEnd
         , project_id
-	, listagg( distinct dataset_name,',') as all_datasets
-	, na_seq_source_id
-	, internal_abbrev
+	    , listagg( distinct dataset_name,',') as all_datasets
+	    , na_seq_source_id
+	    , internal_abbrev
         , 'Y' as matched_result
         from (
                 select ed.name as dataset_name
-		, ab.internal_abbrev 
-                , lrt.*
+		        , ab.internal_abbrev
+                , lrt.gene_source_id
+                , lrt.transcript_length
+                , lrt.gene_novelty
+                , lrt.transcript_novelty
+                , lrt.incomplete_splice_match_type
+                , lrt.min_start
+                , lrt.max_end
+                , lrt.na_seq_source_id
                 , ta.project_id
                 , ta.source_id
+                , sum(count_table.reads) as totalReads
                 from apidb.longreadtranscript lrt
+                , JSON_TABLE(count_data, '$.*' COLUMNS (reads INTEGER PATH '$')) count_table
                 , sres.externaldatabaserelease edr
                 , sres.externaldatabase ed
                 , apidbtuning.transcriptattributes ta
-		, apidbtuning.organismattributes ab
+		        , apidbtuning.organismattributes ab
                 , apidbtuning.datasetPresenter dp
                 where edr.external_database_release_id = lrt.external_database_release_id
                 and ed.external_database_id = edr.external_database_id
                 and ta.gene_source_id = lrt.gene_source_id
-		and ab.organism_name = ta.organism
+		        and ab.organism_name = ta.organism
                 and ed.name = dp.name
-		and lrt.transcript_length >= $$transcript_length$$
-		and (lrt.transcript_novelty in ($$ismTypes$$) or (lrt.transcript_novelty = 'ISM' and lrt.incomplete_splice_match_type in ($$ismTypes$$)))
+		        and lrt.transcript_length >= $$transcript_length$$
+		        and (lrt.transcript_novelty in ($$ismTypes$$) or (lrt.transcript_novelty = 'ISM' and lrt.incomplete_splice_match_type in ($$ismTypes$$)))
+                GROUP BY ed.name, ab.internal_abbrev, lrt.gene_source_id, lrt.transcript_length, lrt.gene_novelty, lrt.transcript_novelty
+                , lrt.incomplete_splice_match_type, lrt.min_start, lrt.max_end, lrt.na_seq_source_id, ta.project_id, ta.source_id
         )
         where dataset_name = '$$long_read_datasets$$'
+        AND totalReads >= $$supporting_read_count$$
         group by source_id, gene_source_id, project_id, na_seq_source_id,internal_abbrev
-        order by source_id desc
 
 	</sql>
     </sqlQuery>

--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1030,7 +1030,7 @@ FROM
 	    <column name="contextEnd"/>
         <sql>
 
-
+        <![CDATA[
 	    select distinct source_id
         , gene_source_id
         , count(source_id) as num_new_models
@@ -1082,7 +1082,7 @@ FROM
         where dataset_name = '$$long_read_datasets$$'
         AND totalReads >= $$supporting_read_count$$
         group by source_id, gene_source_id, project_id, na_seq_source_id,internal_abbrev
-
+        ]]>
 	</sql>
     </sqlQuery>
 

--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1009,16 +1009,16 @@ FROM
 <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
 
    <sqlQuery name="GenesByISM" includeProjects="PlasmoDB,ToxoDB" >
-	<paramRef ref="geneParams.long_read_datasets"/>
+	    <paramRef ref="geneParams.long_read_datasets"/>
         <paramRef ref="geneParams.ismTypes"/>
-	<paramRef ref="SpanParams.transcript_length"/>
+	    <paramRef ref="sharedParams.transcript_length"/>
         <column name="project_id"/>
         <column name="source_id"/>
         <column name="gene_source_id"/>
         <column name="num_new_models"  />
         <column name="transcript_novelty"/>
         <column name="incomplete_splice_match_type"/>
-	<column name="matched_result"/>
+	    <column name="matched_result"/>
         <!-- these used for JBrowse link -->
         <column name="min_start"/>
         <column name="max_end"/>
@@ -1079,9 +1079,9 @@ FROM
     <processQuery name="GenesByISM" 
              includeProjects="EuPathDB"
              processName="org.apidb.apicomplexa.wsfplugin.apifed.ApiFedPlugin">
-	<paramRef ref="geneParams.long_read_datasets"/>
+	    <paramRef ref="geneParams.long_read_datasets"/>
         <paramRef ref="geneParams.ismTypes"/>
-        <paramRef ref="SpanParams.transcript_length"/>
+        <paramRef ref="sharedParams.transcript_length"/>
         <wsColumn name="source_id" width="50" wsName="source_id"/>
         <wsColumn name="gene_source_id" width="50" wsName="gene_source_id"/>
         <wsColumn name="project_id" width="20" />

--- a/Model/lib/wdk/model/questions/queries/spanQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/spanQueries.xml
@@ -111,58 +111,59 @@
         <column name="contextStart"/>
         <column name="contextEnd"/>
         <column name="transcript_novelty"/>
+        <column name="total_count"/>
         
 	<sql includeProjects="PlasmoDB,ToxoDB">
         <![CDATA[
 
-select distinct source_id, project_id , min_start, contextStart, max_end, contextEnd, chr_source_id, internal_abbrev, organism
-, listagg(distinct dataset_name, ', ') WITHIN GROUP (ORDER BY transcript_novelty) AS dataset_name
-,listagg(distinct transcript_novelty, ', ') within group (order by transcript_novelty) as transcript_novelty
-from (
-select distinct
-  source_id
-, project_id
-, min_start
-, case when min_start - 1000 < 1 THEN 1 ELSE min_start - 1000 END as contextStart
-, max_end
-, CASE WHEN max_end + 1000  > length THEN length ELSE max_end + 1000 END as contextEnd
-, chr_source_id
-, internal_abbrev
-, dataset_name
-, organism
-, transcript_novelty
-from(
-             select distinct lrt.na_seq_source_id as chr_source_id
-             ,gsa.project_id
-             ,lrt.min_start
-             ,lrt.max_end
-             ,lrt.na_seq_source_id || ':' || lrt.min_start || '-' ||  lrt.max_end || ':f' as source_id
-             ,ed.name as dataset_name
-             ,ab.internal_abbrev
-             ,gsa.organism
-             ,lrt.transcript_novelty
-             , gsa.length
-        from
-              apidb.longreadtranscript lrt
-             ,apidbtuning.genomicseqattributes gsa
-             ,sres.externaldatabaserelease edr
-             ,sres.externaldatabase ed
-             ,apidbtuning.organismattributes ab
-        where
-             edr.external_database_release_id = lrt.external_database_release_id
-             and ed.external_database_id = edr.external_database_id
-             and gsa.source_id = lrt.na_seq_source_id
-             and ab.organism_name = gsa.organism
-             and lrt.transcript_length >= $$transcript_length$$
-	     and lrt.transcript_novelty in ($$ismTypes_span$$)
-
+        SELECT DISTINCT * FROM (
+            SELECT DISTINCT source_id
+            , project_id
+            , min_start
+            , contextStart
+            , max_end
+            , contextEnd
+            , chr_source_id
+            , internal_abbrev
+            , organism
+            , dataset_name
+            , LISTAGG(DISTINCT transcript_novelty) WITHIN GROUP (ORDER BY transcript_novelty) AS transcript_novelty
+            , SUM(reads) AS total_count
+            FROM (
+                SELECT DISTINCT lrt.na_seq_source_id AS chr_source_id
+                , gsa.project_id
+                , lrt.min_start
+                , CASE WHEN lrt.min_start - 1000 < 1
+                    THEN 1
+                    ELSE lrt.min_start - 1000 END as contextStart
+                , lrt.max_end
+                , CASE WHEN lrt.max_end + 1000 > gsa.length
+                    THEN gsa.length
+                    ELSE lrt.max_end + 1000 END as contextEnd
+                , lrt.na_seq_source_id || ':' || lrt.min_start || '-' || lrt.max_end || ':f' AS source_id
+                , count_table.reads
+                , ed.name AS dataset_name
+                , oa.internal_abbrev
+                , gsa.organism
+                , lrt.transcript_novelty
+                FROM apidb.longreadtranscript lrt
+                , JSON_TABLE(count_data, '$.*' COLUMNS (reads INTEGER PATH '$')) count_table
+                , apidbtuning.genomicseqattributes gsa
+                , sres.externaldatabase ed
+                , sres.externaldatabaserelease edr
+                , apidbtuning.organismattributes oa
+                WHERE edr.external_database_release_id = lrt.external_database_release_id
+                AND ed.external_database_id = edr.external_database_id
+                AND ed.name = '$$long_read_datasets$$'
+                AND gsa.source_id = lrt.na_seq_source_id
+                AND oa.organism_name = gsa.organism
+                AND lrt.transcript_length >= $$transcript_length$$
+                AND lrt.transcript_novelty in ($$ismTypes_span$$)
+            )
+            GROUP BY source_id, project_id, min_start, contextStart, max_end, contextEnd, chr_source_id, internal_abbrev, organism, dataset_name
         )
-        where dataset_name = '$$long_read_datasets$$'
-        order by source_id, min_start
-)
-group by source_id, project_id , min_start, contextStart, max_end, contextEnd, chr_source_id, internal_abbrev, organism
-
-           ]]>
+        WHERE total_count >= $$supporting_read_count$$
+        ]]>
         </sql>
 
     </sqlQuery>

--- a/Model/lib/wdk/model/questions/queries/spanQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/spanQueries.xml
@@ -98,6 +98,7 @@
     <sqlQuery name="DynSpansLongReadBySourceId" includeProjects="PlasmoDB,ToxoDB">
         <paramRef ref="geneParams.long_read_datasets"/>
 	    <paramRef ref="geneParams.ismTypes_span"/>
+        <paramRef ref="sharedParams.supporting_read_count"/>
         <paramRef ref="sharedParams.transcript_length"/>
 	    <column name="source_id"/>
         <column name="project_id"/>
@@ -172,6 +173,7 @@ group by source_id, project_id , min_start, contextStart, max_end, contextEnd, c
              processName="org.apidb.apicomplexa.wsfplugin.apifed.ApiFedPlugin">
         <paramRef ref="geneParams.long_read_datasets"/>
         <paramRef ref="geneParams.ismTypes_span"/>
+        <paramRef ref="sharedParams.supporting_read_count"/>
         <paramRef ref="sharedParams.transcript_length"/>
         <wsColumn name="project_id" width="20" />
         <wsColumn name="transcript_novelty" width="50" wsName="transcript_novelty"/>

--- a/Model/lib/wdk/model/questions/queries/spanQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/spanQueries.xml
@@ -97,9 +97,9 @@
 
     <sqlQuery name="DynSpansLongReadBySourceId" includeProjects="PlasmoDB,ToxoDB">
         <paramRef ref="geneParams.long_read_datasets"/>
-	<paramRef ref="geneParams.ismTypes_span"/>
-        <paramRef ref="SpanParams.transcript_length"/>
-	<column name="source_id"/>
+	    <paramRef ref="geneParams.ismTypes_span"/>
+        <paramRef ref="sharedParams.transcript_length"/>
+	    <column name="source_id"/>
         <column name="project_id"/>
         <column name="min_start"/>
         <column name="max_end"/>
@@ -172,7 +172,7 @@ group by source_id, project_id , min_start, contextStart, max_end, contextEnd, c
              processName="org.apidb.apicomplexa.wsfplugin.apifed.ApiFedPlugin">
         <paramRef ref="geneParams.long_read_datasets"/>
         <paramRef ref="geneParams.ismTypes_span"/>
-        <paramRef ref="SpanParams.transcript_length"/>
+        <paramRef ref="sharedParams.transcript_length"/>
         <wsColumn name="project_id" width="20" />
         <wsColumn name="transcript_novelty" width="50" wsName="transcript_novelty"/>
 


### PR DESCRIPTION
Add a parameter to the long read queries constraining the results by the number of reads supporting a TALON prediction.

As a first pass, I've set the default to 10. 

I've added the number of supporting reads as a column to the output of the Span query. I didn't do this for the gene query because one gene many have more than one TALON model that meets the criteria. However, this will now only return genes where at least one overlapping TALON model meets the cutoff.

Questions:
I'm debating whether 10 is too stringent for this param.  I'm wondering if 5 is better. Any thoughts?
I think we should constrain the Gene Model Characteristics search to the same defaults as these searches. Does that make sense?

This is available on my dev site: [here](https://crouchk.plasmodb.org/plasmodb.crouchk/app/search/transcript/GenesByLongReadEvidence) and [here](https://crouchk.plasmodb.org/plasmodb.crouchk/app/search/genomic-segment/GenomicSpanByLongReadEvidence)

PR is draft, pending:

1. Further work on help text
2. Implementing constraints in Gene Model Characteristics search if we decide to do so.