### PR TITLE
Leverage new htmlHelp attribute for lengthy tooltips

### DIFF
--- a/Model/lib/dst/longReadRnaSeq.dst
+++ b/Model/lib/dst/longReadRnaSeq.dst
@@ -38,22 +38,56 @@ prop=includeProjects
           <columnAttribute name="num_new_models" displayName="Number of transcript models"
           help="Number of transcript models identified for the gene"  align="center"/>
 
-          <columnAttribute name="transcript_novelty" displayName="Transcript Novelty" 
-          help="Describes how the TALON prediction differs from the gene model;
-            Intergenic: Intergenic predictions lack any overlap with known genes; 
-            NIC: Novel In Collection: Prediction uses known splice donors and acceptors but reveals new connections (e.g., skipped exon isoforms);
-            NNC: Novel Not in Collection: Prediction has at least one novel donor or acceptor (i.e., at least one novel exon boundary);
-            ISM: Incomplete Splice Match: Prediction matches subsection of a known transcript model but has a novel putative start or end point;
-            Genomic: Prediction has no overlapping splice junctions compared to known transcripts;
-            Known: Prediction exactly matches a known model;
-            Antisense: Prediction overlaps an existing model but is oriented in the opposite direction" align="center"/>
+          <columnAttribute name="transcript_novelty" displayName="Transcript Novelty" align="center">
+            <htmlHelp><![CDATA[
+              <div>
+                Describes how the TALON prediction differs from the gene model
+                <dl>
+                  <dt>Intergenic:</dt>
+                  <dd>Intergenic predictions lack any overlap with known genes</dd>
 
-          <columnAttribute name="incomplete_splice_match_type" displayName="Talon splice mismatch type"
-          help="Subcategory for ISM predictions;
-                Suffix: Mismatch at 5' end;
-                Prefix: Mismatch at 3' end;
-                Both: Mismatches at both ends;
-                None: Category for other transcript novelty types"  align="center"/>
+                  <dt>Novel In Collection (NIC):</dt>
+                  <dd>Prediction uses known splice donors and acceptors but reveals new connections (e.g., skipped exon isoforms)</dd>
+
+                  <dt>Novel Not in Collection (NNC):</dt>
+                  <dd>Prediction has at least one novel donor or acceptor (i.e., at least one novel exon boundary)</dd>
+
+                  <dt>Incomplete Splice Match (ISM):</dt>
+                  <dd>Prediction matches subsection of a known transcript model but has a novel putative start or end point</dd>
+                  
+                  <dt>Genomic:</dt>
+                  <dd>Prediction has no overlapping splice junctions compared to known transcripts</dd>
+                  
+                  <dt>Known:</dt>
+                  <dd>Prediction exactly matches a known model</dd>
+                  
+                  <dt>Antisense:</dt>
+                  <dd>Prediction overlaps an existing model but is oriented in the opposite direction</dd>
+                </dl>
+              </div>
+            ]]></htmlHelp>
+          </columnAttribute>
+
+          <columnAttribute name="incomplete_splice_match_type" displayName="Talon splice mismatch type" align="center">
+              <htmlHelp><![CDATA[
+                <div>
+                  Subcategory for ISM predictions
+                  <dl>
+                    <dt>Suffix:</dt>
+                    <dd>Mismatch at 5' end</dd>
+                    
+                    <dt>Prefix:</dt>
+                    <dd>Mismatch at 3' end</dd>
+                    
+                    <dt>Both:</dt>
+                    <dd>Mismatches at both ends</dd>
+                    
+                    <dt>None:</dt>
+                    <dd>Category for other transcript novelty types</dd>
+                  </dl>
+                </div>
+                  ]]></htmlHelp>   
+          </columnAttribute>
 
           <columnAttribute name="contextStart" internal="true"/>
           <columnAttribute name="contextEnd" internal="true"/>


### PR DESCRIPTION
Makes use of the work done for https://github.com/VEuPathDB/web-monorepo/issues/838

More specifically, I've formatted the help message rendered in column tooltips for both `transcript_novelty` and `incomplete_splice_match_type` by using [the new `htmlHelp` attribute](https://github.com/VEuPathDB/WDK/pull/80) and [wiring the client to choose this htmlHelp attribute over the help attribute](https://github.com/VEuPathDB/web-monorepo/pull/851) when present.

![image](https://github.com/VEuPathDB/ApiCommonModel/assets/69446567/f3f72e2b-33ad-4874-be00-0ff3a6b67c69)
