### PR TITLE
Move WGCNA's visibleHelp content to question's new searchVisibleHelp attribute

### DIFF
--- a/Model/lib/dst/rnaSeqTemplates.dst
+++ b/Model/lib/dst/rnaSeqTemplates.dst
@@ -139,6 +139,24 @@ prop=organismAbbrevDisplay
         A module is a group of genes that have similar expression profiles across samples. The above modules were found using an <a href="https://www.biorxiv.org/content/10.1101/234062v1.full.pdf">iterative Weighted Gene Correlation Network Analysis</a>.  
       ]]>
     </description>
+
+    <searchVisibleHelp>
+      <![CDATA[
+        <div class="wgcna-banner">
+          <div class="wgcna-banner-img-container">
+            <a target="_blank" href="@LEGACY_WEBAPP_BASE_URL@/app/workspace/analyses/DS_82dc5abc7f/new/learn">
+              <img id="wgcna_help_image" src="" />
+            </a>
+            <div><a target="_blank" href="@LEGACY_WEBAPP_BASE_URL@/app/workspace/analyses/DS_82dc5abc7f/new/learn"><strong>Study Explorer</strong></a></div>
+          </div>
+          <div>
+            <p>
+              Use the new <a target="_blank" href="@LEGACY_WEBAPP_BASE_URL@/app/workspace/analyses/DS_82dc5abc7f/new/learn">WGCNA Study Explorer</a> to discover co-expression networks of interest.  For example, a co-expression network may have a positive correlation with study metadata such as a patient’s platelet count or age.  The Study Explorer offers metadata filters and visualization tools to help conceptualize co-expression networks and choose one of interest.
+            </p>
+          </div>
+        </div>
+      ]]>
+    </searchVisibleHelp>    
   </question>
 >templateTextEnd<
 

--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <wdkModel>
 
-  <constant name="wgcnaModuleSearchVisibleHelp">
-    <![CDATA[
-            <div class="wgcna-banner">
-              <div class="wgcna-banner-img-container">
-                <a target="_blank" href="@LEGACY_WEBAPP_BASE_URL@/app/workspace/analyses/DS_82dc5abc7f/new/learn">
-                  <img id="wgcna_help_image" src="" />
-                </a>
-                <div><a target="_blank" href="@LEGACY_WEBAPP_BASE_URL@/app/workspace/analyses/DS_82dc5abc7f/new/learn"><strong>Study Explorer</strong></a></div>
-              </div>
-              <div>
-                <p>
-                  Use the new <a target="_blank" href="@LEGACY_WEBAPP_BASE_URL@/app/workspace/analyses/DS_82dc5abc7f/new/learn">WGCNA Study Explorer</a> to discover co-expression networks of interest.  For example, a co-expression network may have a positive correlation with study metadata such as a patient’s platelet count or age.  The Study Explorer offers metadata filters and visualization tools to help conceptualize co-expression networks and choose one of interest.
-                </p>
-              </div>
-            </div>
-          ]]>
-</constant>
-
   <querySet name="GeneId" queryType="id" isCacheable="true">
 
     <postCacheUpdateSql excludeProjects="UniDB">
@@ -2590,12 +2572,7 @@ if these values change, then they must be updated in the WdkQueryPlugin.java fil
   <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
 
     <sqlQuery name="GenesByWGCNAModule" excludeProjects="EuPathDB" >
-        <paramRef ref="geneParams.wgcnaParam">
-          <visibleHelp><![CDATA[
-           %%wgcnaModuleSearchVisibleHelp%%
-
-          ]]></visibleHelp>
-        </paramRef>
+        <paramRef ref="geneParams.wgcnaParam"/>
         <paramRef ref="geneParams.wgcnaDataset"/>
         <paramRef ref="geneParams.wgcna_correlation_cutoff"/>
         <column name="project_id"/>


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/53977

Specifically, this request in the comments:
> at UX Apr 3 2024 it was suggested to have the help under the search title, not witin a parameter. This will help understanding the search better.

Depends on client changes from https://github.com/VEuPathDB/web-monorepo/pull/995 and WDK changes from https://github.com/VEuPathDB/WDK/pull/86