### PR TITLE
Mass spec fixes.

### DIFF
--- a/Model/lib/jbrowse/functions.conf
+++ b/Model/lib/jbrowse/functions.conf
@@ -35,7 +35,7 @@ massSpecColor = function( feature, variableName, glyphObject, track ) {
     var colors = color.split(';');
     return colors[0];
   }
-  return 'yellow';
+  return 'gray';
  }
 massSpecLabel = function(track, feature, featureDiv) {
   return(feature.get("sample"));
@@ -587,32 +587,23 @@ liftoffGeneDetails = function(track, feature, featureDiv) {
  }
 massSpecDetails = function(track, feature, featureDiv) {
   var c = track.browser.config;
-  var rows = new Array();
-  var count = feature.get("count");
-  var seq =  feature.get("pepseq");
-  var extdbname = feature.get("extdbname");
-  var experiment = feature.get("experiment");
-  var sample = feature.get("sample");
-  var phospho_site = feature.get("modsite");
-  var ontology_names = feature.get("ontology");
-  var tb = "<table><tr><th>Location</th><th>Modified Residue</th><th>Modification Type</th></tr>";
-  var start = feature.get("startm");
-  if(phospho_site && phospho_site != 'NA') {
-    var residue = feature.get("residue");
-    var locs =  phospho_site.split(';');
-    var term = ontology_names.split(';');
-    var residues = residue.split(';');
-    for (i = 0; i < locs.length; i++) { 
-       tb = tb + "<tr><td>" + locs[i] + "</td><td>" + residues[i] + "</td><td>" + term[i] + "</td></tr>";
-    }
-  tb = tb + "</table>"; 
-  }
-  rows.push(c.twoColRow('Experiment:', experiment));
-  rows.push(c.twoColRow('Sample:', sample));
-  rows.push(c.twoColRow('Sequence:', seq));
-  rows.push(c.twoColRow('Spectrum Count:', count));
-  return c.table(rows);
- }
+  container = dojo.create('div', {
+      className: 'detail feature-detail feature-detail-' + track.name.replace(/\s+/g, '_').toLowerCase(),
+      innerHTML: ''
+    });
+  var coreDetails = dojo.create('div', {
+       className: 'core'
+    }, container);
+  var fmt = dojo.hitch(track, 'renderDetailField', coreDetails);
+  coreDetails.innerHTML += '<h2 class="sectiontitle">Mass Spec Details</h2>';
+  fmt( 'Sample', feature.get("sample_name"), feature );
+  fmt( 'Sequence', feature.get("peptide"), feature );
+  fmt( 'Spectrum Count', feature.get("spectrum_count"), feature );
+  var endDetails = dojo.create('div', {
+             className: 'end'
+          }, container);
+  var hitchEnd = dojo.hitch(track, 'renderDetailField', endDetails);
+  return container;  }
 gsnapUnifiedIntronJunctionTitleFxn = function(track, feature, featureDiv) {
   var c = track.browser.config;
   return c.gsnapUnifiedIntronJunctionTitle(track, feature, featureDiv);

--- a/Model/lib/perl/JBrowseTrackConfig/ProteinExpressionMassSpec.pm
+++ b/Model/lib/perl/JBrowseTrackConfig/ProteinExpressionMassSpec.pm
@@ -17,29 +17,27 @@ sub new {
     $datasetConfig->setSubcategory("Protein Expression");
 
     $self->setId($args->{key});
-    $self->setLabel($args->{label}); 
+    $self->setLabel($args->{label});
     $self->setGlyph($args->{glyph});
 
     my $store;
 
     if($self->getApplicationType() eq 'jbrowse' || $self->getApplicationType() eq 'apollo') {
         $store = ApiCommonModel::Model::JBrowseTrackConfig::GFFStore->new($args);
-	$store->setQueryParamsHash($args->{query_params});
     }
     else {
         # TODO
 	$store = ApiCommonModel::Model::JBrowseTrackConfig::GFFStore->new($args);
-        $store->setQueryParamsHash($args->{query_params});
     }
 
     $self->setStore($store);
-    
-    $self->setGlyph("JBrowse/View/FeatureGlyph/Segments") unless(defined $self->getGlyph());
+    $self->setGlyph("JBrowse/View/FeatureGlyph/Box") unless(defined $self->getGlyph());
 
     my $detailsFunction = "{massSpecDetails}";
     $self->setOnClickContent($detailsFunction);
     $self->setViewDetailsContent($detailsFunction);
     $self->setDisplayMode("compact");
+    $self->setBorderColor("black");
 
     return $self;
 }

--- a/Model/lib/perl/JBrowseTrackConfig/UnifiedMassSpecTrackConfig.pm
+++ b/Model/lib/perl/JBrowseTrackConfig/UnifiedMassSpecTrackConfig.pm
@@ -24,7 +24,6 @@ sub new {
 
     if($self->getApplicationType() eq 'jbrowse' || $self->getApplicationType() eq 'apollo') {
         $store = ApiCommonModel::Model::JBrowseTrackConfig::RestStore->new($args);
-        $store->setQuery("domain:UnifiedMassSpecPeptides");
     }
     else {
         # TODO

--- a/Model/lib/perl/JbrowseOrgSpecificAaTracks.pm
+++ b/Model/lib/perl/JbrowseOrgSpecificAaTracks.pm
@@ -350,12 +350,6 @@ sub addProteinExpressionMassSpec {
 
     my $relativePathToGffFile = "${nameForFileNames}/massSpec/gff/${datasetExtdbName}/ms_peptides_protein_align.gff.gz";
 
-    my $queryParams = {         
-                            'edName' => "like '${datasetExtdbName}'",
-                            'feature' => $feature,
-                            'seqType' => "protein",
-                                           };
-
     my $massSpec = ApiCommonModel::Model::JBrowseTrackConfig::ProteinExpressionMassSpec->new({  
                                                                                                 project_name => $projectName,
                                                                                                 build_number => $buildNumber,
@@ -367,7 +361,6 @@ sub addProteinExpressionMassSpec {
                                                                                                 study_display_name => $datasetDisplayName,
                                                                                                 summary => $summary,
                                                                                                 application_type => $applicationType,
-                                                                                                query_params => $queryParams,
                                                                                                 dataset_presenter_id => $datasetPresenterId,
 												glyph => "JBrowse/View/FeatureGlyph/Box",
                                                                                               })->getConfigurationObject();
@@ -377,13 +370,8 @@ sub addProteinExpressionMassSpec {
 
   if($hasPTMDataset) {
 
-  my $ptmQueryParams  = {
-                            'seqType' => "protein",
-                            'feature' => "domain:UnifiedPostTraslationalMod",
-                                           };
-
   my $unifiedPtm = ApiCommonModel::Model::JBrowseTrackConfig::UnifiedPostTranslationalMod->new({application_type => $applicationType,
-                                                                                               query_params => $ptmQueryParams,
+
                                                                                               })->getConfigurationObject();
 
     push @{$result->{tracks}}, $unifiedPtm if($unifiedPtm);


### PR DESCRIPTION
Fixed the mouse-over to have info we have in the gff files.
Made the glyphs boxes instead of segments (lines).
Adjusted the color and borderColor so that the individual glyphs can be seen.
Removed all references to query params, as this is not needed now. 