### PR TITLE
Fix SQL for 3D structure predictions section on gene record page

### DIFF
--- a/Model/lib/wdk/model/records/geneTableQueries.xml
+++ b/Model/lib/wdk/model/records/geneTableQueries.xml
@@ -3759,30 +3759,25 @@ from apidbTuning.AllGeneProducts
       <column name="transcript_ids"/>
       <sql>
         <![CDATA[
-          SELECT
-              ta.gene_source_id AS search_term
-            ,  ta.gene_source_id AS source_id
-            , dr.primary_identifier AS pdb_template
-            , ta.project_id
-            , string_agg(ta.source_id, ', ') within GROUP(ORDER BY ta.source_id) AS transcript_ids
-          FROM
-              dots.aafeature aaf
-            , dots.DbRefaaFeature drnf
-            , sres.DbRef dr
-            , sres.ExternalDatabaseRelease edr
-            , sres.ExternalDatabase ed
-            , ApidbTuning.TranscriptAttributes ta
-          WHERE
-            aaf.aa_sequence_id = ta.aa_sequence_id
-            AND aaf.aa_feature_id = drnf.aa_feature_id
-            AND drnf.db_ref_id = dr.db_ref_id
-            AND dr.external_database_release_id = edr.external_database_release_id
-            AND edr.external_database_id = ed.external_database_id
-            AND ed.name = 'pfal3D7_dbxref_simple_gene2PredictedProteinStructures_RSRC'
-          GROUP BY
-              ta.gene_source_id
-            , ta.project_id
-            , dr.primary_identifier
+	SELECT
+	    ta.gene_source_id AS search_term
+	    , ta.gene_source_id AS source_id
+	    , dr.primary_identifier AS pdb_template
+	    , ta.project_id
+	    , string_agg(ta.source_id, ', ' ORDER BY ta.source_id) AS transcript_ids
+	FROM
+	    dots.aafeature aaf
+	JOIN dots.DbRefaaFeature drnf ON aaf.aa_feature_id = drnf.aa_feature_id
+	JOIN sres.DbRef dr ON drnf.db_ref_id = dr.db_ref_id
+	JOIN sres.ExternalDatabaseRelease edr ON dr.external_database_release_id = edr.external_database_release_id
+	JOIN sres.ExternalDatabase ed ON edr.external_database_id = ed.external_database_id
+	JOIN ApidbTuning.TranscriptAttributes ta ON aaf.aa_sequence_id = ta.aa_sequence_id
+	WHERE
+	    ed.name = 'pfal3D7_dbxref_simple_gene2PredictedProteinStructures_RSRC'
+	GROUP BY
+	    ta.gene_source_id
+	    , ta.project_id
+	    , dr.primary_identifier
         ]]>
       </sql>
     </sqlQuery>


### PR DESCRIPTION
Edited SQL for Postgres to fix the 3D structure predictions section on gene record page.