### PR TITLE
Added missing ncRNASeq tracks to jbrowse tracks.conf files

### DIFF
--- a/Model/bin/jbrowseOrganismSpecificTracks
+++ b/Model/bin/jbrowseOrganismSpecificTracks
@@ -70,7 +70,7 @@ my $datasetProperties = $datasetProps;
 &addSynteny($applicationType, $dbh, $result);
 &addDatasets($dbh, \%datasets) unless($isApollo);
 &addChipChipTracks($dbh, $result, $datasetProperties);
-&addSmallNcRnaSeq;
+#&addSmallNcRnaSeq;
 
 &addProteinExpressionMassSpec;
 &addVCF($dbh, $result, $datasetProperties, $nameForFileNames);

--- a/Model/lib/jbrowse/bcinB05-10/tracks.conf
+++ b/Model/lib/jbrowse/bcinB05-10/tracks.conf
@@ -1,0 +1,101 @@
+[tracks.bcinB05-10_smallNcRna_veloso_sRNA_Dcl1_Dcl2-1-26s_rep1_Bcinerea_2022_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Transcriptome profiling data of <i>Botrytis cinerea</i> infection on whole plant <i>Solanum lycopersicum</i>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('bcinB05-10_smallNcRna_veloso_sRNA_Bcinerea_2022_RSRC', 'bcinB05-10'); }
+key=Dcl1_Dcl2-1-26s_rep1 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=BcinereaB05-10/bam/veloso_sRNA_Bcinerea_2022/Dcl1_Dcl2-1-26s_rep1/Dcl1_Dcl2-1-26s_rep1.bam
+label=Dcl1_Dcl2-1-26s_rep1 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=sRNA profiling data of Botrytis cinerea infection on tomato plant leaves
+metadata.attribution=Veloso et al. 2022
+metadata.description=Transcriptome profiling data of Botrytis cinerea infection on whole plant Solanum lycopersicum
+
+[tracks.bcinB05-10_smallNcRna_veloso_sRNA_Dcl1_Dcl2-1-29s_rep2_Bcinerea_2022_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Transcriptome profiling data of <i>Botrytis cinerea</i> infection on whole plant <i>Solanum lycopersicum</i>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('bcinB05-10_smallNcRna_veloso_sRNA_Bcinerea_2022_RSRC', 'bcinB05-10'); }
+key=Dcl1_Dcl2-1-26s_rep1 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=BcinereaB05-10/bam/veloso_sRNA_Bcinerea_2022/Dcl1_Dcl2-1-29s_rep2/Dcl1_Dcl2-1-29s_rep2.bam
+label=Dcl1_Dcl2-1-29s_rep2 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=sRNA profiling data of Botrytis cinerea infection on tomato plant leaves
+metadata.attribution=Veloso et al. 2022
+metadata.description=Transcriptome profiling data of Botrytis cinerea infection on whole plant Solanum lycopersicum
+
+[tracks.bcinB05-10_smallNcRna_veloso_sRNA_Dcl1_Dcl2-1-30s_rep3_Bcinerea_2022_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Transcriptome profiling data of <i>Botrytis cinerea</i> infection on whole plant <i>Solanum lycopersicum</i>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('bcinB05-10_smallNcRna_veloso_sRNA_Bcinerea_2022_RSRC', 'bcinB05-10'); }
+key=Dcl1_Dcl2-1-30s_rep3 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=BcinereaB05-10/bam/veloso_sRNA_Bcinerea_2022/Dcl1_Dcl2-1-30s_rep3/Dcl1_Dcl2-1-30s_rep3.bam
+label=Dcl1_Dcl2-1-30s_rep3 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=sRNA profiling data of Botrytis cinerea infection on tomato plant leaves
+metadata.attribution=Veloso et al. 2022
+metadata.description=Transcriptome profiling data of Botrytis cinerea infection on whole plant Solanum lycopersicum
+
+[tracks.bcinB05-10_smallNcRna_veloso_sRNA_delta_ku70_rep1_Bcinerea_2022_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Transcriptome profiling data of <i>Botrytis cinerea</i> infection on whole plant <i>Solanum lycopersicum</i>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('bcinB05-10_smallNcRna_veloso_sRNA_Bcinerea_2022_RSRC', 'bcinB05-10'); }
+key=delta_ku70_rep1 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=BcinereaB05-10/bam/veloso_sRNA_Bcinerea_2022/delta_ku70_rep1/delta_ku70_rep1.bam
+label=delta_ku70_rep1 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=sRNA profiling data of Botrytis cinerea infection on tomato plant leaves
+metadata.attribution=Veloso et al. 2022
+metadata.description=Transcriptome profiling data of Botrytis cinerea infection on whole plant Solanum lycopersicum
+
+[tracks.bcinB05-10_smallNcRna_veloso_sRNA_delta_ku70_rep2_Bcinerea_2022_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Transcriptome profiling data of <i>Botrytis cinerea</i> infection on whole plant <i>Solanum lycopersicum</i>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('bcinB05-10_smallNcRna_veloso_sRNA_Bcinerea_2022_RSRC', 'bcinB05-10'); }
+key=delta_ku70_rep2 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=BcinereaB05-10/bam/veloso_sRNA_Bcinerea_2022/delta_ku70_rep2/delta_ku70_rep2.bam
+label=delta_ku70_rep2 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=sRNA profiling data of Botrytis cinerea infection on tomato plant leaves
+metadata.attribution=Veloso et al. 2022
+metadata.description=Transcriptome profiling data of Botrytis cinerea infection on whole plant Solanum lycopersicum
+
+[tracks.bcinB05-10_smallNcRna_veloso_sRNA_delta_ku70_rep3_Bcinerea_2022_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Transcriptome profiling data of <i>Botrytis cinerea</i> infection on whole plant <i>Solanum lycopersicum</i>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('bcinB05-10_smallNcRna_veloso_sRNA_Bcinerea_2022_RSRC', 'bcinB05-10'); }
+key=delta_ku70_rep3 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=BcinereaB05-10/bam/veloso_sRNA_Bcinerea_2022/delta_ku70_rep3/delta_ku70_rep3.bam
+label=delta_ku70_rep3 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=sRNA profiling data of Botrytis cinerea infection on tomato plant leaves
+metadata.attribution=Veloso et al. 2022
+metadata.description=Transcriptome profiling data of Botrytis cinerea infection on whole plant Solanum lycopersicum

--- a/Model/lib/jbrowse/ehisHM1IMSS/tracks.conf
+++ b/Model/lib/jbrowse/ehisHM1IMSS/tracks.conf
@@ -34,3 +34,37 @@ fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName("ehisHM1IMSS_T
 style.color=black
 style.strandArrow=false
 metadata.trackType=Segments
+
+[tracks.ehisHM1IMSS_smallNcRna_Singh_Ago2IP_Small_RNA_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('RNA-Seq of small RNAs that co-precipitate with the Argonaute 2-2 protein in virulent <i>E. histolytica</i> strain HM1:IMSS and small RNAs from the avirulent strain Rahman.<br> At views > 3kb a plot of coverage across the genome is seen. <br> At < 3kb, individual alignments can be viewed, with sequence information visible at <100bp.<br><br>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('ehisHM1IMSS_smallNcRna_Singh_Small_RNA_RSRC', 'Argonaute 2-2 Associated small RNAs'); }
+key=HM1IMSS_Ago2IP Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=EhistolyticaHM1IMSS/bam/Singh_Small_RNA/HM1IMSS_Ago2IP/HM1IMSS_Ago2IP.bam
+label=HM1IMSS_Ago2IP Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Argonaute 2-2 Associated small RNAs
+metadata.attribution=Zhang et al.
+metadata.description=RNA-Seq of small RNAs that co-precipitate with the Argonaute 2-2 protein in virulent <i>E. histolytica</i> strain HM1:IMSS and small RNAs from the avirulent strain Rahman.<br> At views > 3kb a plot of coverage across the genome is seen. <br> At < 3kb, individual alignments can be viewed, with sequence information visible at <100bp.<br><br>
+
+[tracks.ehisHM1IMSS_smallNcRna_Singh_Rahman_Small_RNA_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('RNA-Seq of small RNAs that co-precipitate with the Argonaute 2-2 protein in virulent <i>E. histolytica</i> strain HM1:IMSS and small RNAs from the avirulent strain Rahman.<br> At views > 3kb a plot of coverage across the genome is seen. <br> At < 3kb, individual alignments can be viewed, with sequence information visible at <100bp.<br><br>', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('ehisHM1IMSS_smallNcRna_Singh_Small_RNA_RSRC', 'Argonaute 2-2 Associated small RNAs'); }
+key=Rahman Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=EhistolyticaHM1IMSS/bam/Singh_Small_RNA/Rahman/Rahman.bam
+label=Rahman Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Argonaute 2-2 Associated small RNAs
+metadata.attribution=Zhang et al.
+metadata.description=RNA-Seq of small RNAs that co-precipitate with the Argonaute 2-2 protein in virulent <i>E. histolytica</i> strain HM1:IMSS and small RNAs from the avirulent strain Rahman.<br> At views > 3kb a plot of coverage across the genome is seen. <br> At < 3kb, individual alignments can be viewed, with sequence information visible at <100bp.<br><br>

--- a/Model/lib/jbrowse/gassAWB2019/tracks.conf
+++ b/Model/lib/jbrowse/gassAWB2019/tracks.conf
@@ -1,0 +1,50 @@
+[tracks.gassAWB2019_smallNcRna_TDIP1_Wang_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Illumina RNA-Seq of small RNAs that co-precipitate with the Argonaute protein', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('gassAWB2019_smallNcRna_Wang_RSRC', 'gassAWB2019'); }
+key=TDIP1 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=GintestinalisAssemblageAWB2019/bam/Wang/TDIP1/TDIP1.bam
+label=TDIP1 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Argonaute-Associated Small RNAs (WB)
+metadata.attribution=Saraiya et al.
+metadata.description=Illumina RNA-Seq of small RNAs that co-precipitate with the Argonaute protein
+
+[tracks.gassAWB2019_smallNcRna_TDIP2_Wang_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Illumina RNA-Seq of small RNAs that co-precipitate with the Argonaute protein', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('gassAWB2019_smallNcRna_Wang_RSRC', 'gassAWB2019'); }
+key=TDIP2 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=GintestinalisAssemblageAWB2019/bam/Wang/TDIP2/TDIP2.bam
+label=TDIP2 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Argonaute-Associated Small RNAs (WB)
+metadata.attribution=Saraiya et al.
+metadata.description=Illumina RNA-Seq of small RNAs that co-precipitate with the Argonaute protein
+
+[tracks.gassAWB2019_smallNcRna_TDSIP_Wang_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Illumina RNA-Seq of small RNAs that co-precipitate with the Argonaute protein', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('gassAWB2019_smallNcRna_Wang_RSRC', 'gassAWB2019'); }
+key=TDSIP Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=GintestinalisAssemblageAWB2019/bam/Wang/TDSIP/TDSIP.bam
+label=TDSIP Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Argonaute-Associated Small RNAs (WB)
+metadata.attribution=Saraiya et al.
+metadata.description=Illumina RNA-Seq of small RNAs that co-precipitate with the Argonaute protein

--- a/Model/lib/jbrowse/ncraOR74A/tracks.conf
+++ b/Model/lib/jbrowse/ncraOR74A/tracks.conf
@@ -1,0 +1,50 @@
+[tracks.ncraOR74A_Stajich_Small_RNA_4PF_smallNcRnaSample_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Endogenous small RNA profiles from <i>N. crassa</i> protoperithecia and perithecia at 2 and 4 days postfertilization.', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('ncraOR74A_smallNcRna_Stajich_Small_RNA_RSRC', 'Small RNA-Seq profiles during sexual development in Neurospora crassa'); }
+key=4PF Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=NcrassaOR74A/bam/Stajich_Small_RNA/4PF/4PF.bam
+label=4PF Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Small RNA-Seq profiles during sexual development in Neurospora crassa
+metadata.attribution=Wang et al.
+metadata.description=Endogenous small RNA profiles from <i>N. crassa</i> protoperithecia and perithecia at 2 and 4 days postfertilization.
+
+[tracks.ncraOR74A_Stajich_Small_RNA_2PF_smallNcRnaSample_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Endogenous small RNA profiles from <i>N. crassa</i> protoperithecia and perithecia at 2 and 4 days postfertilization.', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('ncraOR74A_smallNcRna_Stajich_Small_RNA_RSRC', 'Small RNA-Seq profiles during sexual development in Neurospora crassa'); }
+key=2PF Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=NcrassaOR74A/bam/Stajich_Small_RNA/2PF/2PF.bam
+label=2PF Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Small RNA-Seq profiles during sexual development in Neurospora crassa
+metadata.attribution=Wang et al.
+metadata.description=Endogenous small RNA profiles from <i>N. crassa</i> protoperithecia and perithecia at 2 and 4 days postfertilization.
+
+[tracks.ncraOR74A_Stajich_Small_RNA_PP_smallNcRnaSample_RSRC]
+fmtMetaValue_Description=function() { return datasetDescription('Endogenous small RNA profiles from <i>N. crassa</i> protoperithecia and perithecia at 2 and 4 days postfertilization.', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('ncraOR74A_smallNcRna_Stajich_Small_RNA_RSRC', 'Small RNA-Seq profiles during sexual development in Neurospora crassa'); }
+key=PP Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=NcrassaOR74A/bam/Stajich_Small_RNA/PP/PP.bam
+label=PP Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Small RNA-Seq profiles during sexual development in Neurospora crassa
+metadata.attribution=Wang et al.
+metadata.description=Endogenous small RNA profiles from <i>N. crassa</i> protoperithecia and perithecia at 2 and 4 days postfertilization.

--- a/Model/lib/jbrowse/tgonME49/tracks.conf
+++ b/Model/lib/jbrowse/tgonME49/tracks.conf
@@ -1,3 +1,20 @@
+[tracks.tgonME49_Gregory_ME49_ncRNA_ME49]
+fmtMetaValue_Description=function() { return datasetDescription('<i>T. gondii</i> ME49 ncRNA Illumina sequences aligned to the ME49 Genome', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('tgonME49_smallNcRna_Gregory_ME49_ncRNA_RSRC', 'Tachyzoite non-coding RNA (ME49)'); }
+key=ME49 Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=TgondiiME49/bam/Gregory_ME49_ncRNA/ME49/ME49.bam
+label=ME49 Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Tachyzoite non-coding RNA (ME49)
+metadata.attribution=Gregory
+metadata.description=<i>T. gondii</i> ME49 ncRNA Illumina sequences aligned to the ME49 Genome
+
 [tracks.tgonME49_Gregory_ME49_ncRNA_RH]
 fmtMetaValue_Description=function() { return datasetDescription('<i>T. gondii</i> ME49 ncRNA Illumina sequences aligned to the ME49 Genome', ''); }
 unsafePopup=true

--- a/Model/lib/jbrowse/tgonME49/tracks.conf
+++ b/Model/lib/jbrowse/tgonME49/tracks.conf
@@ -1,3 +1,20 @@
+[tracks.tgonME49_Gregory_ME49_ncRNA_RH]
+fmtMetaValue_Description=function() { return datasetDescription('<i>T. gondii</i> ME49 ncRNA Illumina sequences aligned to the ME49 Genome', ''); }
+unsafePopup=true
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName('tgonME49_smallNcRna_Gregory_ME49_ncRNA_RSRC', 'Tachyzoite non-coding RNA (ME49)'); }
+key=RH Small Non-coding RNAs
+yScalePosition=left
+storeClass=JBrowse/Store/SeqFeature/BAM
+urlTemplate=/a/service/jbrowse/store?data=TgondiiME49/bam/Gregory_ME49_ncRNA/RH/RH.bam
+label=RH Small Non-coding RNAs
+type=SmallRNAPlugin/View/Track/smAlignments
+category=Transcriptomics
+metadata.subcategory=small non-coding RNA
+metadata.trackType=Small RNA
+metadata.dataset=Tachyzoite non-coding RNA (ME49)
+metadata.attribution=Gregory
+metadata.description=<i>T. gondii</i> ME49 ncRNA Illumina sequences aligned to the ME49 Genome
+
 [tracks.tgonME49_Lourido_TSS_RSRC_curated]
 storeClass=JBrowse/Store/SeqFeature/BigBed
 urlTemplate=/a/service/jbrowse/auxiliary?data=ToxoDB/tgonME49/rnaSeq/Markus_five_prime_rnaSeq/Data_S2.TSSs_ME49TzBz.curated.bigBed
@@ -24,7 +41,7 @@ maxFeatureGlyphExpansion=500
 key=5prime tags ME49 Tachyzoite replicate A (Forward strand)
 label=5prime tags ME49 Tachyzoite replicate A (Forward strand)
 type=JBrowse/View/Track/Wiggle/XYPlot
-category=Gene Models
+
 autoscale=local
 yScalePosition=left
 metadata.subcategory=Transcripton start sites (TSSs)

--- a/Model/lib/jbrowse/tgonME49/tracks.conf
+++ b/Model/lib/jbrowse/tgonME49/tracks.conf
@@ -41,7 +41,7 @@ maxFeatureGlyphExpansion=500
 key=5prime tags ME49 Tachyzoite replicate A (Forward strand)
 label=5prime tags ME49 Tachyzoite replicate A (Forward strand)
 type=JBrowse/View/Track/Wiggle/XYPlot
-
+category=Gene Models
 autoscale=local
 yScalePosition=left
 metadata.subcategory=Transcripton start sites (TSSs)


### PR DESCRIPTION
I have added missing small ncRNASeq tracks to the tracks.conf files for the following organisms:

bcinB05-10 
gassAWB2019
ncraOR74A
ehisHM1IMSS
tgonME49 

I rebuilt my dev sites to confirm that the tracks are now available.