### PR TITLE
Antibody array WDK: EDA transcript columns and gene record graph tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ target
 
 # JBrowse
 /Model/lib/jbrowse/auto_generated/
+.worktrees

--- a/Model/lib/dst/antibodyArray.dst
+++ b/Model/lib/dst/antibodyArray.dst
@@ -250,7 +250,7 @@ prop=includeProjects
     LEFT OUTER JOIN (
       SELECT * FROM public.crosstab(
         'SELECT gene_ids.gene_id,
-                CONCAT(''${edaStudyStableId}_'', anc.sample_stable_id) AS sample_col,
+                REPLACE(CONCAT(''${edaStudyStableId}_'', anc.sample_stable_id), ''.'', ''_'') AS sample_col,
                 av_int.number_value AS intensity
          FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_int
          JOIN eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
@@ -263,7 +263,7 @@ prop=includeProjects
            ON gene_ids.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
          WHERE av_int.attribute_stable_id = ''NORMALIZED_INTENSITY''
          ORDER BY 1, 2',
-        'SELECT CONCAT(''${edaStudyStableId}_'', sample_stable_id) AS sample_col
+        'SELECT REPLACE(CONCAT(''${edaStudyStableId}_'', sample_stable_id), ''.'', ''_'') AS sample_col
          FROM (SELECT DISTINCT sample_stable_id
                FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
          ORDER BY sample_col'
@@ -285,7 +285,7 @@ prop=includeProjects
 
           <sql>
             <![CDATA[
-           SELECT CONCAT('${edaStudyStableId}_', sample_stable_id) AS name,
+           SELECT REPLACE(CONCAT('${edaStudyStableId}_', sample_stable_id), '.', '_') AS name,
                   sample_stable_id::text AS display_name,
                   'number' AS column_type,
                   'Normalized intensity from ${datasetName}' AS help,

--- a/Model/lib/dst/antibodyArray.dst
+++ b/Model/lib/dst/antibodyArray.dst
@@ -226,3 +226,141 @@ Note that changing the sample subset will reset any group assignments you have a
         </dynamicAttributes>
     </question>
 >templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaAttributeQueriesNumeric
+anchorFile=ApiCommonModel/Model/lib/wdk/model/records/transcriptAttributeQueries.xml
+prop=datasetName
+prop=edaStudyStableId
+prop=edaEntityAbbrev
+prop=includeProjects
+>templateTextStart<
+        <sqlQuery name="AntibodyArrayIntensities${datasetName}"
+                  doNotTest="true"
+                  attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}"
+                  includeProjects="${includeProjects}">
+            <column name="source_id"/>
+            <column name="gene_source_id"/>
+            <column name="project_id"/>
+            <sql>
+              <![CDATA[
+  SELECT ta.source_id, ta.project_id, ta.gene_source_id, p.*
+  FROM apidbtuning.TranscriptAttributes ta
+    LEFT OUTER JOIN (
+      SELECT * FROM public.crosstab(
+        'SELECT gene_ids.gene_id,
+                CONCAT(''${edaStudyStableId}_'', anc.sample_stable_id) AS sample_col,
+                av_int.number_value AS intensity
+         FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_int
+         JOIN eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
+           ON anc.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+         JOIN (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) AS gene_id
+               FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av
+               JOIN apidbtuning.GeneId gi ON gi.id = av.string_value
+               WHERE av.attribute_stable_id = ''VEUPATHDB_GENE_ID''
+               GROUP BY av.${edaEntityAbbrev}_stable_id) gene_ids
+           ON gene_ids.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+         WHERE av_int.attribute_stable_id = ''NORMALIZED_INTENSITY''
+         ORDER BY 1, 2',
+        'SELECT CONCAT(''${edaStudyStableId}_'', sample_stable_id) AS sample_col
+         FROM (SELECT DISTINCT sample_stable_id
+               FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
+         ORDER BY sample_col'
+      ) AS ct(gene_id text, &&META_ATTRIBUTE_COLUMNS_FOR_CROSSTAB&&)
+    ) p ON ta.gene_source_id = p.gene_id
+              ]]>
+            </sql>
+        </sqlQuery>
+
+       <sqlQuery name="MetaAntibodyArrayIntensities${datasetName}" includeProjects="${includeProjects}">
+          <column name="name" />
+          <column name="display_name" />
+          <column name="help" />
+          <column name="reporter_name" />
+          <column name="reporter_display" />
+          <column name="reporter_description" />
+          <column name="reporter_implementation" />
+          <column name="reporter_properties" />
+
+          <sql>
+            <![CDATA[
+           SELECT CONCAT('${edaStudyStableId}_', sample_stable_id) AS name,
+                  sample_stable_id::text AS display_name,
+                  'number' AS column_type,
+                  'Normalized intensity from ${datasetName}' AS help,
+                  'histogram' AS reporter_name,
+                  'Histogram' AS reporter_display,
+                  'Display a histogram of the values' AS reporter_description,
+                  'org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter' AS reporter_implementation,
+                  null AS reporter_properties
+           FROM (SELECT DISTINCT sample_stable_id
+                 FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
+           ORDER BY sample_stable_id
+            ]]>
+          </sql>
+       </sqlQuery>
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaAttributeRef
+anchorFile=ApiCommonModel/Model/lib/wdk/model/records/transcriptRecord.xml
+prop=datasetName
+prop=includeProjects
+>templateTextStart<
+              <attributeQueryRef ref="TranscriptAttributes.AntibodyArrayIntensities${datasetName}" attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}" includeProjects="${includeProjects}">
+              </attributeQueryRef>
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaAttributeCategory
+anchorFile=ApiCommonModel/Model/lib/wdk/ontology/individuals.txt
+prop=datasetName
+prop=datasetDisplayName
+>templateTextStart<
+AntibodyArrayDataset_${datasetName}	http://edamontology.org/topic_3360	Immunology	DatasetRecordClasses.DatasetRecordClass	dataset	${datasetName}	${datasetDisplayName}	results
+TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}	AntibodyArrayDataset_${datasetName}		TranscriptRecordClasses.TranscriptRecordClass	attributeMetaQuery	MetaAntibodyArrayIntensities${datasetName}			gene		results	download
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaGeneTableSql
+anchorFile=ApiCommonModel/Model/lib/wdk/model/records/geneTableQueries.xml
+prop=datasetName
+prop=edaStudyStableId
+prop=edaEntityAbbrev
+>templateTextStart<
+               UNION
+               SELECT '${datasetName}' AS dataset_name , string_value AS source_id
+               FROM eda.ATTRIBUTEvalue_${edaStudyStableId}_${edaEntityAbbrev} av
+               WHERE av.attribute_stable_id = 'VEUPATHDB_GENE_ID'
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayDataTableGeneTableSql
+anchorFile=ApiCommonModel/Model/lib/wdk/model/records/geneTableQueries.xml
+prop=datasetName
+prop=edaStudyStableId
+prop=edaEntityAbbrev
+>templateTextStart<
+UNION
+SELECT genes.string_value AS gene,
+       ag.display_name AS variable,
+       av.string_value,
+       av.number_value,
+       av.date_value,
+       '${datasetName}' AS dataset_id
+FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av,
+     eda.attributegraph_${edaStudyStableId}_${edaEntityAbbrev} ag,
+     (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) as string_value
+      FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av
+      JOIN apidbtuning.GeneId gi ON gi.id = av.string_value
+      WHERE av.attribute_stable_id = 'VEUPATHDB_GENE_ID'
+      GROUP BY av.${edaEntityAbbrev}_stable_id) genes
+WHERE av.attribute_stable_id = ag.stable_id
+  AND av.${edaEntityAbbrev}_stable_id = genes.${edaEntityAbbrev}_stable_id
+  AND av.attribute_stable_id != 'VEUPATHDB_GENE_ID'
+>templateTextEnd<

--- a/Model/lib/dst/antibodyArray.dst
+++ b/Model/lib/dst/antibodyArray.dst
@@ -5,15 +5,15 @@ prop=datasetName
 prop=projectName
 >templateTextStart<
       <sqlQuery name="MetadataDataset${datasetName}">
-             <column name="internal"/>
-             <column name="term"/>
-          <sql>
-           <![CDATA[
-             SELECT '${datasetName}' AS term,
-                    '${datasetName}' AS internal
-            ]]>
-          </sql>
-        </sqlQuery>
+	     <column name="internal"/>
+	     <column name="term"/>
+	  <sql>
+	   <![CDATA[
+	     SELECT '${datasetName}' AS term,
+		    '${datasetName}' AS internal
+	    ]]>
+	  </sql>
+	</sqlQuery>
 
 >templateTextEnd<
 
@@ -40,70 +40,70 @@ prop=includeProjectsExcludeEuPathDB
 >templateTextStart<
 
     <question name="GenesByAntibodyArray${datasetName}" includeProjects="${includeProjects}" newBuild="${buildNumberIntroduced}"
-         displayName="${organismAbbrevDisplay} ${datasetDisplayName} Antibody Array (p-value)"
-         shortDisplayName="${datasetShortDisplayName} (p-val)"
-         searchCategory="Host Response"
-         queryRef="GeneId.GenesByTTestWithMetadata"
-         recordClassRef="TranscriptRecordClasses.TranscriptRecordClass">
+	 displayName="${organismAbbrevDisplay} ${datasetDisplayName} Antibody Array (p-value)"
+	 shortDisplayName="${datasetShortDisplayName} (p-val)"
+	 searchCategory="Host Response"
+	 queryRef="GeneId.GenesByTTestWithMetadata"
+	 recordClassRef="TranscriptRecordClasses.TranscriptRecordClass">
 
-        <paramRef ref="sharedParams.metadata_datasets" queryRef="GeneVQ.MetadataDataset${datasetName}" visible="false"/>
+	<paramRef ref="sharedParams.metadata_datasets" queryRef="GeneVQ.MetadataDataset${datasetName}" visible="false"/>
 
 <sqlParamValue name="function">'${function}'</sqlParamValue> 
 	<attributesList includeProjects="${includeProjectsExcludeEuPathDB}"
 	   summary="organism,gene_product,p_value, avg_group_two,avg_group_one,dynamic_graph"
-            sorting="p_value asc" /> 
+	    sorting="p_value asc" /> 
 
        <attributesList includeProjects="EuPathDB"
-              summary="organism,gene_product,p_value, avg_group_two,avg_group_one"
-              sorting="p_value asc"         
-        /> 
+	      summary="organism,gene_product,p_value, avg_group_two,avg_group_one"
+	      sorting="p_value asc"	    
+	/> 
 
-        <summary>
-            <![CDATA[ 
-           Find genes based on Immune Response in Clinical Isolates.
-            ]]>
-        </summary>
+	<summary>
+	    <![CDATA[ 
+	   Find genes based on Immune Response in Clinical Isolates.
+	    ]]>
+	</summary>
 
-        <description>
-            <![CDATA[
-             Find genes based on Immune Response in Clinical Isolates. <br />
-             ${optionalQuestionDescription}
-            ]]>
-        </description>
-        <dynamicAttributes>
-           <columnAttribute name="p_value" displayName="P Value" align="center"
-                            help="p-value based on t-test for independent samples with unequal variances">
-	        <reporter name="histogram" displayName="Histogram" scopes=""                                                                     
-                  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">                                               
-                  <description>Display the histogram of the values of this attribute</description>                                               
-                  <property name="type">float</property>
-                </reporter>
+	<description>
+	    <![CDATA[
+	     Find genes based on Immune Response in Clinical Isolates. <br />
+	     ${optionalQuestionDescription}
+	    ]]>
+	</description>
+	<dynamicAttributes>
+	   <columnAttribute name="p_value" displayName="P Value" align="center"
+			    help="p-value based on t-test for independent samples with unequal variances">
+		<reporter name="histogram" displayName="Histogram" scopes=""									 
+		  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">						 
+		  <description>Display the histogram of the values of this attribute</description>						 
+		  <property name="type">float</property>
+		</reporter>
 	  </columnAttribute>
-           <columnAttribute name="avg_group_one" displayName="Avg Comp ${function_display}" align="center" 
-                            help="$$function_help$$ comparison samples">
-	        <reporter name="histogram" displayName="Histogram" scopes=""                                                                     
-                  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">                                               
-                  <description>Display the histogram of the values of this attribute</description>                                               
-                  <property name="type">int</property>
-                </reporter>
+	   <columnAttribute name="avg_group_one" displayName="Avg Comp ${function_display}" align="center" 
+			    help="$$function_help$$ comparison samples">
+		<reporter name="histogram" displayName="Histogram" scopes=""									 
+		  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">						 
+		  <description>Display the histogram of the values of this attribute</description>						 
+		  <property name="type">int</property>
+		</reporter>
 	  </columnAttribute>
-           <columnAttribute name="avg_group_two" displayName="Avg Ref ${function_display}" align="center"
-                            help="$$function_help$$ reference samples">
-	        <reporter name="histogram" displayName="Histogram" scopes=""                                                                     
-                  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">                                               
-                  <description>Display the histogram of the values of this attribute</description>                                               
-                  <property name="type">int</property>
-                </reporter>
+	   <columnAttribute name="avg_group_two" displayName="Avg Ref ${function_display}" align="center"
+			    help="$$function_help$$ reference samples">
+		<reporter name="histogram" displayName="Histogram" scopes=""									 
+		  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">						 
+		  <description>Display the histogram of the values of this attribute</description>						 
+		  <property name="type">int</property>
+		</reporter>
 	  </columnAttribute>
-           <textAttribute name="dynamic_graph" displayName="Expression - graph"
-                        inReportMaker="false" truncateTo="100000" sortable="false" includeProjects="${includeProjectsExcludeEuPathDB}">
-           <text>
-                <![CDATA[
-                <img src="/cgi-bin/dataPlotter.pl?type=${graphModule}&project_id=${projectName}&id=$$primary_key$$&template=0&dataset=${datasetName}&fmt=png&thumb=1"/>
-                ]]>
-           </text>
-           </textAttribute>
-        </dynamicAttributes>
+	   <textAttribute name="dynamic_graph" displayName="Expression - graph"
+			inReportMaker="false" truncateTo="100000" sortable="false" includeProjects="${includeProjectsExcludeEuPathDB}">
+	   <text>
+		<![CDATA[
+		<img src="/cgi-bin/dataPlotter.pl?type=${graphModule}&project_id=${projectName}&id=$$primary_key$$&template=0&dataset=${datasetName}&fmt=png&thumb=1"/>
+		]]>
+	   </text>
+	   </textAttribute>
+	</dynamicAttributes>
 
     </question>
 
@@ -123,11 +123,11 @@ prop=includeProjectsExcludeEuPathDB
 			  displayName="${datasetShortDisplayName} - Intensity Graph"
 			  inReportMaker="false" truncateTo="100000" sortable="false"
 			  includeProjects="${includeProjectsExcludeEuPathDB}">
-              <text>
-                <![CDATA[
-                <img src="/cgi-bin/dataPlotter.pl?type=${graphModule}&project_id=${projectName}&template=1&fmt=png&id=$$primary_key$$&dataset=${datasetName}&vp=_LEGEND,xy_scatter&thumb=1"/>
-                ]]>
-              </text>
+	      <text>
+		<![CDATA[
+		<img src="/cgi-bin/dataPlotter.pl?type=${graphModule}&project_id=${projectName}&template=1&fmt=png&id=$$primary_key$$&dataset=${datasetName}&vp=_LEGEND,xy_scatter&thumb=1"/>
+		]]>
+	      </text>
 	   </textAttribute>
 >templateTextEnd<
 
@@ -137,7 +137,7 @@ anchorFile=ApiCommonModel/Model/lib/wdk/model/questions/categories.xml
 prop=datasetName
 prop=includeProjects
 >templateTextStart<
-            <questionRef includeProjects="${includeProjects}">GeneQuestions.GenesByAntibodyArray${datasetName}</questionRef>
+	    <questionRef includeProjects="${includeProjects}">GeneQuestions.GenesByAntibodyArray${datasetName}</questionRef>
 >templateTextEnd<
 
 [templateStart]
@@ -152,27 +152,27 @@ prop=includeProjects
 prop=antibodyArrayWdkAttributes
 >templateTextStart<
     <question name="GenesByAntibodyArrayEdaSubset_${datasetName}" includeProjects="${includeProjects}" newBuild="${buildNumberIntroduced}"
-         displayName="${datasetDisplayName} Antibody Array"
-         shortDisplayName="${datasetShortDisplayName} (QAA)"
-         queryRef="GeneId.GenesByEdaVizWithCompute"
-         recordClassRef="TranscriptRecordClasses.TranscriptRecordClass">
+	 displayName="${datasetDisplayName} Antibody Array"
+	 shortDisplayName="${datasetShortDisplayName} (QAA)"
+	 queryRef="GeneId.GenesByEdaVizWithCompute"
+	 recordClassRef="TranscriptRecordClasses.TranscriptRecordClass">
 
-        <paramRef ref="geneParams.eda_dataset_id" default="${presenterId}" visible="false"/>
-        <paramRef ref="geneParams.eda_analysis_spec" allowEmpty="true" prompt="Filter genes based on antibody array data"/>
+	<paramRef ref="geneParams.eda_dataset_id" default="${presenterId}" visible="false"/>
+	<paramRef ref="geneParams.eda_analysis_spec" allowEmpty="true" prompt="Filter genes based on antibody array data"/>
 
-        <propertyList name="edaNotebookType">
-          <value>antibodyArrayNotebook</value>
-        </propertyList>
+	<propertyList name="edaNotebookType">
+	  <value>antibodyArrayNotebook</value>
+	</propertyList>
 
-         <attributesList
-              summary="organism,gene_product,effectSize,pValue"
-              sorting="effectSize desc" />
+	 <attributesList
+	      summary="organism,gene_product,effectSize,pValue"
+	      sorting="effectSize desc" />
   <!-- TO ADD  ${antibodyArrayWdkAttributes} -->
 
 	<summary><![CDATA[
-        Find genes with differential expression in antibody array data based on EDA analysis.
-          ]]>
-        </summary>
+	Find genes with differential expression in antibody array data based on EDA analysis.
+	  ]]>
+	</summary>
     <description> <![CDATA[
 Find proteins with differential abundance between two groups of samples in an antibody array experiment.
 This search uses a guided notebook within the site that runs Limma, a widely-used statistical method for analysing microarray and antibody array data (Ritchie et al., 2015).
@@ -206,24 +206,24 @@ A lower p-value (raw or adjusted) indicates a more statistically confident call.
 <u>Removing outliers</u>: If the PCA plot reveals samples that cluster away from the rest (potential outliers or contaminated arrays), you can exclude them using the <b>Select Samples</b> step at the top of the notebook.
 Apply a filter on the sample identifier or a metadata variable to remove those samples before running Limma.
 Note that changing the sample subset will reset any group assignments you have already made in the Limma step, so it is best to check the PCA first before defining your groups.
-          ]]>
-        </description>
-        <dynamicAttributes>
-           <columnAttribute name="effectSize" displayName="Effect Size" align="center">
-                <reporter name="histogram" displayName="Histogram" scopes=""
-                  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">
-                  <description>Display the histogram of the values of this attribute</description>
-                  <property name="type">float</property>
-                </reporter>
-           </columnAttribute>
-           <columnAttribute name="pValue" displayName="P-Value" align="center">
-                <reporter name="histogram" displayName="Histogram" scopes=""
-                  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">
-                  <description>Display the histogram of the values of this attribute</description>
-                  <property name="type">float</property>
-                </reporter>
-          </columnAttribute>
-        </dynamicAttributes>
+	  ]]>
+	</description>
+	<dynamicAttributes>
+	   <columnAttribute name="effectSize" displayName="Effect Size" align="center">
+		<reporter name="histogram" displayName="Histogram" scopes=""
+		  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">
+		  <description>Display the histogram of the values of this attribute</description>
+		  <property name="type">float</property>
+		</reporter>
+	   </columnAttribute>
+	   <columnAttribute name="pValue" displayName="P-Value" align="center">
+		<reporter name="histogram" displayName="Histogram" scopes=""
+		  implementation="org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter">
+		  <description>Display the histogram of the values of this attribute</description>
+		  <property name="type">float</property>
+		</reporter>
+	  </columnAttribute>
+	</dynamicAttributes>
     </question>
 >templateTextEnd<
 
@@ -236,69 +236,69 @@ prop=edaStudyStableId
 prop=edaEntityAbbrev
 prop=includeProjects
 >templateTextStart<
-        <sqlQuery name="AntibodyArrayIntensities${datasetName}"
-                  doNotTest="true"
-                  attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}"
-                  includeProjects="${includeProjects}">
-            <column name="source_id"/>
-            <column name="gene_source_id"/>
-            <column name="project_id"/>
-            <sql>
-              <![CDATA[
+	<sqlQuery name="AntibodyArrayIntensities${datasetName}"
+		  doNotTest="true"
+		  attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}"
+		  includeProjects="${includeProjects}">
+	    <column name="source_id"/>
+	    <column name="gene_source_id"/>
+	    <column name="project_id"/>
+	    <sql>
+	      <![CDATA[
   SELECT ta.source_id, ta.project_id, ta.gene_source_id, p.*
   FROM apidbtuning.TranscriptAttributes ta
     LEFT OUTER JOIN (
       SELECT * FROM public.crosstab(
-        'SELECT gene_ids.gene_id,
-                REPLACE(CONCAT(''${edaStudyStableId}_'', anc.sample_stable_id), ''.'', ''_'') AS sample_col,
-                av_int.number_value AS intensity
-         FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_int
-         JOIN eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
-           ON anc.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
-         JOIN (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) AS gene_id
-               FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av
-               JOIN apidbtuning.GeneId gi ON gi.id = av.string_value
-               WHERE av.attribute_stable_id = ''VEUPATHDB_GENE_ID''
-               GROUP BY av.${edaEntityAbbrev}_stable_id) gene_ids
-           ON gene_ids.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
-         WHERE av_int.attribute_stable_id = ''NORMALIZED_INTENSITY''
-         ORDER BY 1, 2',
-        'SELECT REPLACE(CONCAT(''${edaStudyStableId}_'', sample_stable_id), ''.'', ''_'') AS sample_col
-         FROM (SELECT DISTINCT sample_stable_id
-               FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
-         ORDER BY sample_col'
+	'SELECT gene_ids.gene_id,
+		REPLACE(CONCAT(''${edaStudyStableId}_'', anc.sample_stable_id), ''.'', ''_'') AS sample_col,
+		av_int.number_value AS intensity
+	 FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_int
+	 JOIN eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
+	   ON anc.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+	 JOIN (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) AS gene_id
+	       FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av
+	       JOIN apidbtuning.GeneId gi ON gi.id = av.string_value
+	       WHERE av.attribute_stable_id = ''VEUPATHDB_GENE_ID''
+	       GROUP BY av.${edaEntityAbbrev}_stable_id) gene_ids
+	   ON gene_ids.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+	 WHERE av_int.attribute_stable_id = ''NORMALIZED_INTENSITY''
+	 ORDER BY 1, 2',
+	'SELECT REPLACE(CONCAT(''${edaStudyStableId}_'', sample_stable_id), ''.'', ''_'') AS sample_col
+	 FROM (SELECT DISTINCT sample_stable_id
+	       FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
+	 ORDER BY sample_col'
       ) AS ct(gene_id text, &&META_ATTRIBUTE_COLUMNS_FOR_CROSSTAB&&)
     ) p ON ta.gene_source_id = p.gene_id
-              ]]>
-            </sql>
-        </sqlQuery>
+	      ]]>
+	    </sql>
+	</sqlQuery>
 
        <sqlQuery name="MetaAntibodyArrayIntensities${datasetName}" includeProjects="${includeProjects}">
-          <column name="name" />
-          <column name="display_name" />
-          <column name="help" />
-          <column name="reporter_name" />
-          <column name="reporter_display" />
-          <column name="reporter_description" />
-          <column name="reporter_implementation" />
-          <column name="reporter_properties" />
+	  <column name="name" />
+	  <column name="display_name" />
+	  <column name="help" />
+	  <column name="reporter_name" />
+	  <column name="reporter_display" />
+	  <column name="reporter_description" />
+	  <column name="reporter_implementation" />
+	  <column name="reporter_properties" />
 
-          <sql>
-            <![CDATA[
-           SELECT REPLACE(CONCAT('${edaStudyStableId}_', sample_stable_id), '.', '_') AS name,
-                  sample_stable_id::text AS display_name,
-                  'number' AS column_type,
-                  'Normalized intensity from ${datasetName}' AS help,
-                  'histogram' AS reporter_name,
-                  'Histogram' AS reporter_display,
-                  'Display a histogram of the values' AS reporter_description,
-                  'org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter' AS reporter_implementation,
-                  null AS reporter_properties
-           FROM (SELECT DISTINCT sample_stable_id
-                 FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
-           ORDER BY sample_stable_id
-            ]]>
-          </sql>
+	  <sql>
+	    <![CDATA[
+	   SELECT REPLACE(CONCAT('${edaStudyStableId}_', sample_stable_id), '.', '_') AS name,
+		  sample_stable_id::text AS display_name,
+		  'number' AS column_type,
+		  'Normalized intensity from ${datasetName}' AS help,
+		  'histogram' AS reporter_name,
+		  'Histogram' AS reporter_display,
+		  'Display a histogram of the values' AS reporter_description,
+		  'org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter' AS reporter_implementation,
+		  null AS reporter_properties
+	   FROM (SELECT DISTINCT sample_stable_id
+		 FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev}) s
+	   ORDER BY sample_stable_id
+	    ]]>
+	  </sql>
        </sqlQuery>
 >templateTextEnd<
 
@@ -309,8 +309,98 @@ anchorFile=ApiCommonModel/Model/lib/wdk/model/records/transcriptRecord.xml
 prop=datasetName
 prop=includeProjects
 >templateTextStart<
-              <attributeQueryRef ref="TranscriptAttributes.AntibodyArrayIntensities${datasetName}" attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}" includeProjects="${includeProjects}">
-              </attributeQueryRef>
+	      <attributeQueryRef ref="TranscriptAttributes.AntibodyArrayIntensities${datasetName}" attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}" includeProjects="${includeProjects}">
+	      </attributeQueryRef>
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaAttributeQueriesNumericByDataset
+anchorFile=ApiCommonModel/Model/lib/wdk/model/records/transcriptAttributeQueries.xml
+prop=datasetName
+prop=edaStudyStableId
+prop=edaEntityAbbrev
+prop=includeProjects
+prop=subDatasetSuffix
+prop=subDatasetFilterValue
+prop=subDatasetAttributeStableId
+>templateTextStart<
+	<sqlQuery name="AntibodyArrayIntensities${datasetName}_${subDatasetSuffix}"
+		  doNotTest="true"
+		  attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}_${subDatasetSuffix}"
+		  includeProjects="${includeProjects}">
+	    <column name="source_id"/>
+	    <column name="gene_source_id"/>
+	    <column name="project_id"/>
+	    <sql>
+	      <![CDATA[
+  SELECT ta.source_id, ta.project_id, ta.gene_source_id, p.*
+  FROM apidbtuning.TranscriptAttributes ta
+    LEFT OUTER JOIN (
+      SELECT * FROM public.crosstab(
+	'SELECT gene_ids.gene_id,
+		REPLACE(CONCAT(''${edaStudyStableId}_'', anc.sample_stable_id), ''.'', ''_'') AS sample_col,
+		av_int.number_value AS intensity
+	 FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_int
+	 JOIN eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
+	   ON anc.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+	 JOIN (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) AS gene_id
+	       FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av
+	       JOIN apidbtuning.GeneId gi ON gi.id = av.string_value
+	       WHERE av.attribute_stable_id = ''VEUPATHDB_GENE_ID''
+	       GROUP BY av.${edaEntityAbbrev}_stable_id) gene_ids
+	   ON gene_ids.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+	 JOIN eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_dataset
+	   ON av_dataset.${edaEntityAbbrev}_stable_id = av_int.${edaEntityAbbrev}_stable_id
+	  AND av_dataset.attribute_stable_id = ''${subDatasetAttributeStableId}''
+	  AND av_dataset.string_value = ''${subDatasetFilterValue}''
+	 WHERE av_int.attribute_stable_id = ''NORMALIZED_INTENSITY''
+	 ORDER BY 1, 2',
+	'SELECT REPLACE(CONCAT(''${edaStudyStableId}_'', s.sample_stable_id), ''.'', ''_'') AS sample_col
+	 FROM (SELECT DISTINCT anc.sample_stable_id
+	       FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
+	       JOIN eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_dataset
+		 ON av_dataset.${edaEntityAbbrev}_stable_id = anc.${edaEntityAbbrev}_stable_id
+		AND av_dataset.attribute_stable_id = ''${subDatasetAttributeStableId}''
+		AND av_dataset.string_value = ''${subDatasetFilterValue}'') s
+	 ORDER BY sample_col'
+      ) AS ct(gene_id text, &&META_ATTRIBUTE_COLUMNS_FOR_CROSSTAB&&)
+    ) p ON ta.gene_source_id = p.gene_id
+	      ]]>
+	    </sql>
+	</sqlQuery>
+
+       <sqlQuery name="MetaAntibodyArrayIntensities${datasetName}_${subDatasetSuffix}" includeProjects="${includeProjects}">
+	  <column name="name" />
+	  <column name="display_name" />
+	  <column name="help" />
+	  <column name="reporter_name" />
+	  <column name="reporter_display" />
+	  <column name="reporter_description" />
+	  <column name="reporter_implementation" />
+	  <column name="reporter_properties" />
+
+	  <sql>
+	    <![CDATA[
+	   SELECT REPLACE(CONCAT('${edaStudyStableId}_', s.sample_stable_id), '.', '_') AS name,
+		  s.sample_stable_id::text AS display_name,
+		  'number' AS column_type,
+		  'Normalized intensity from ${datasetName} (${subDatasetSuffix})' AS help,
+		  'histogram' AS reporter_name,
+		  'Histogram' AS reporter_display,
+		  'Display a histogram of the values' AS reporter_description,
+		  'org.gusdb.wdk.model.report.reporter.HistogramAttributeReporter' AS reporter_implementation,
+		  null AS reporter_properties
+	   FROM (SELECT DISTINCT anc.sample_stable_id
+		 FROM eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc
+		 JOIN eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av_dataset
+		   ON av_dataset.${edaEntityAbbrev}_stable_id = anc.${edaEntityAbbrev}_stable_id
+		  AND av_dataset.attribute_stable_id = '${subDatasetAttributeStableId}'
+		  AND av_dataset.string_value = '${subDatasetFilterValue}') s
+	   ORDER BY s.sample_stable_id
+	    ]]>
+	  </sql>
+       </sqlQuery>
 >templateTextEnd<
 
 
@@ -320,8 +410,32 @@ anchorFile=ApiCommonModel/Model/lib/wdk/ontology/individuals.txt
 prop=datasetName
 prop=datasetDisplayName
 >templateTextStart<
-AntibodyArrayDataset_${datasetName}	http://edamontology.org/topic_3360	Immunology	DatasetRecordClasses.DatasetRecordClass	dataset	${datasetName}	${datasetDisplayName}	results
-TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}	AntibodyArrayDataset_${datasetName}		TranscriptRecordClasses.TranscriptRecordClass	attributeMetaQuery	MetaAntibodyArrayIntensities${datasetName}			gene		results	download
+AntibodyArrayDataset_${datasetName}	http://edamontology.org/topic_3360	Immunology	DatasetRecordClasses.DatasetRecordClass	dataset	${datasetName}	${datasetDisplayName}						results
+TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}	AntibodyArrayDataset_${datasetName}		TranscriptRecordClasses.TranscriptRecordClass	attributeMetaQuery	MetaAntibodyArrayIntensities${datasetName}				gene		results	download
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaAttributeRefByDataset
+anchorFile=ApiCommonModel/Model/lib/wdk/model/records/transcriptRecord.xml
+prop=datasetName
+prop=subDatasetSuffix
+prop=includeProjects
+>templateTextStart<
+              <attributeQueryRef ref="TranscriptAttributes.AntibodyArrayIntensities${datasetName}_${subDatasetSuffix}" attributeMetaQueryRef="TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}_${subDatasetSuffix}" includeProjects="${includeProjects}">
+              </attributeQueryRef>
+>templateTextEnd<
+
+
+[templateStart]
+name=antibodyArrayEdaAttributeCategoryByDataset
+anchorFile=ApiCommonModel/Model/lib/wdk/ontology/individuals.txt
+prop=datasetName
+prop=datasetDisplayName
+prop=subDatasetSuffix
+>templateTextStart<
+AntibodyArrayDataset_${datasetName}_${subDatasetSuffix}	http://edamontology.org/topic_3360	Immunology	DatasetRecordClasses.DatasetRecordClass	dataset	${datasetName}	${datasetDisplayName} (${subDatasetSuffix})						results
+TranscriptAttributes.MetaAntibodyArrayIntensities${datasetName}_${subDatasetSuffix}	AntibodyArrayDataset_${datasetName}_${subDatasetSuffix}		TranscriptRecordClasses.TranscriptRecordClass	attributeMetaQuery	MetaAntibodyArrayIntensities${datasetName}_${subDatasetSuffix}				gene		results	download
 >templateTextEnd<
 
 

--- a/Model/lib/wdk/model/records/geneRecord.xml
+++ b/Model/lib/wdk/model/records/geneRecord.xml
@@ -1343,6 +1343,46 @@ name" internal="true"/>
         </table>
 
 
+        <table name="EdaAntibodyArrayDatasets"
+                 displayName="Antibody Array Datasets"
+                 inReportMaker="false"
+                 includeProjects="PlasmoDB,UniDB"
+                 queryRef="GeneTables.EdaAntibodyArrayDatasets">
+
+            <columnAttribute internal="true" displayName="source_id" name="source_id"/>
+            <columnAttribute internal="true" displayName="project_id" name="project_id"/>
+            <columnAttribute internal="true" displayName="project_id_url" name="project_id_url"/>
+            <columnAttribute internal="true" displayName="graph_ids" name="graph_ids"/>
+            <columnAttribute internal="true" displayName="genus_species" name="genus_species"/>
+            <columnAttribute internal="true" displayName="mainOpen" name="mainOpen"/>
+            <columnAttribute internal="true" displayName="dataOpen" name="dataOpen"/>
+            <columnAttribute displayName="Name" name="display_name"/>
+            <columnAttribute internal="true" displayName="description" name="description"/>
+            <columnAttribute internal="true" displayName="has_graph_data" name="has_graph_data"/>
+            <columnAttribute internal="true" displayName="has_meta_data" name="has_meta_data"/>
+            <columnAttribute internal="true" displayName="meta_data_categories" name="meta_data_categories"/>
+            <columnAttribute internal="true" displayName="dataset_name" name="dataset_name"/>
+            <columnAttribute internal="true" displayName="dataset_id" name="dataset_id"/>
+            <columnAttribute displayName="Summary" name="summary"/>
+            <columnAttribute displayName="Attribution" name="short_attribution"/>
+            <columnAttribute displayName="Assay Type" name="assay_type"/>
+            <columnAttribute internal="true" displayName="DefaultGraphId" name="default_graph_id"/>
+            <columnAttribute internal="true"  displayName="Plots" name="plot_configs_json"/>
+
+            <propertyList name="hideDatasetLink"><value>true</value></propertyList>
+        </table>
+
+
+        <table name="EdaAntibodyArrayGraphsDataTable"
+                inReportMaker="false"
+                displayName="Antibody Array Graphs Data Table"
+                includeProjects="PlasmoDB,UniDB"
+                queryRef="GeneTables.EdaAntibodyArrayGraphsDataTable">
+            <columnAttribute name="dataset_id" displayName="Dataset" internal="true"/>
+            <columnAttribute name="variable" displayName="Variable"/>
+            <columnAttribute name="value" displayName="Value"/>
+        </table>
+
         <table name="PhenotypeScoreGraphs"
                  displayName="Phenotype Graphs"
                  inReportMaker="false"

--- a/Model/lib/wdk/model/records/geneTableQueries.xml
+++ b/Model/lib/wdk/model/records/geneTableQueries.xml
@@ -1135,6 +1135,111 @@ from (
         </sqlQuery>
 
 
+       <sqlQuery name="EdaAntibodyArrayDatasets" includeProjects="PlasmoDB,UniDB">
+            <column name="source_id" />
+            <column name="project_id" />
+            <column name="project_id_url" />
+            <column name="graph_ids" />
+            <column name="default_graph_id" />
+            <column name="species" />
+            <column name="genus_species" />
+            <column name="mainOpen" />
+            <column name="dataOpen" />
+            <column name="display_name" />
+            <column name="description" />
+            <column name="has_graph_data"/>
+            <column name="has_meta_data"/>
+            <column name="meta_data_categories"/>
+            <column name="dataset_name"/>
+            <column name="dataset_id"/>
+            <column name="summary"/>
+            <column name="short_attribution"/>
+            <column name="assay_type"/>
+            <column name="plot_configs_json"/>
+            <sql>
+
+<![CDATA[
+select g.*
+     , CASE WHEN '@PROJECT_ID@' = 'UniDB' THEN 'EuPathDB' ELSE g.project_id END AS project_id_url
+     , regexp_substr(graph_ids, '[^,]*') as default_graph_id
+from (
+        select ga.source_id, ga.project_id,
+             ga.organism as gene_organism, ga.genus_species ,
+             psgene.profile_graph_id as graph_ids,
+             case when psgene.profile_graph_id is null then 0 else 1 end as has_graph_data,
+             'TRUE' as mainOpen, 'FALSE' as dataOpen,
+             'FALSE' has_meta_data, '' as meta_data_categories,
+             graph_descrip.*, dp.summary, dp.short_attribution, dp.display_name,
+             dp.description, 'Antibody Array' as assay_type, dp.dataset_presenter_id as dataset_id, dp.name as dataset_name
+      from webready.GeneAttributes_p ga,
+           apidbtuning.DatasetDatasource dds,
+           apidbtuning.datasetPresenter dp
+           LEFT JOIN (
+             SELECT dataset_name as graph_dataset_name,
+                    JSON_ARRAYAGG(
+                      JSON_OBJECT(
+                        'plotName' VALUE plot_name,
+                        'plotType' VALUE plot_type,
+                        'xAxisEntityId' VALUE x_axis_entity_id,
+                        'yAxisEntityId' VALUE y_axis_entity_id,
+                        'xAxisVariableId' VALUE x_axis_variable_id,
+                        'yAxisVariableId' VALUE y_axis_variable_id,
+                        'displaySpecVariableId' VALUE 'VEUPATHDB_GENE_ID',
+                        'displayMode' VALUE 'highlight',
+                        'xMin' VALUE x_min,
+                        'xMax' VALUE x_max,
+                        'yMin' VALUE y_min,
+                        'yMax' VALUE y_max
+                       )
+                      ) AS plot_configs_json
+             FROM apidbtuning.edagenegraph
+             GROUP BY graph_dataset_name
+           ) graph_descrip ON graph_descrip.graph_dataset_name = dp.name,
+           (WITH dataset_genes as (
+               SELECT '' as dataset_name, '' as source_id
+               -- TEMPLATE_ANCHOR antibodyArrayEdaGeneTableSql
+           )
+          select ga.source_id, p.dataset_name, p.source_id as profile_graph_id
+          from dataset_genes p
+          join webready.geneid_p gi on gi.id = p.source_id and gi.org_abbrev IN (%%PARTITION_KEYS%%)
+          join webready.GeneAttributes_p ga on ga.source_id = gi.gene and ga.org_abbrev IN (%%PARTITION_KEYS%%)
+            ) psgene
+        where ga.source_id = psgene.source_id
+          and psgene.dataset_name = dds.name
+          and dds.dataset_presenter_id = dp.dataset_presenter_id
+          and dds.category = 'Immunology'
+) g
+ ]]>
+       </sql>
+
+        </sqlQuery>
+
+
+          <sqlQuery name="EdaAntibodyArrayGraphsDataTable" isCacheable="false" includeProjects="PlasmoDB,UniDB">
+            <column name="source_id"/>
+            <column name="project_id"/>
+            <column name="dataset_id"/>
+            <column name="variable"/>
+            <column name="value"/>
+            <sql>
+            <![CDATA[
+SELECT ga.source_id, ga.project_id, gd.variable, coalesce(gd.string_value, coalesce(round(gd.number_value, 4)::text, gd.date_value::text)) AS value, gd.dataset_id
+FROM webready.GeneAttributes_p ga, (
+   SELECT '' as gene,
+          '' as variable,
+          '' as string_value,
+          0 as number_value,
+          DATE '2000-01-01' as date_value,
+          'HAPPY_BIRTHDAY' as dataset_id
+   -- TEMPLATE_ANCHOR antibodyArrayDataTableGeneTableSql
+   ) gd
+   WHERE ga.source_id = gd.gene
+     AND ga.org_abbrev IN (%%PARTITION_KEYS%%)
+        ]]>
+      </sql>
+    </sqlQuery>
+
+
     <sqlQuery name="PhenotypeScoreGraphs" includeProjects="PlasmoDB,UniDB">
       <column name="source_id" />
       <column name="project_id" />

--- a/Model/lib/wdk/model/records/transcriptAttributeQueries.xml
+++ b/Model/lib/wdk/model/records/transcriptAttributeQueries.xml
@@ -192,6 +192,8 @@
 
     <!-- TEMPLATE_ANCHOR cellularLocalizationEdaAttributeQueriesString -->
 
+    <!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeQueriesNumeric -->
+
     <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
     <!-- Transcripts per gene -->
     <!-- ATTENTION: this SQL cannot be used by a boolean step because it does not have the matched_result dynamic column -->

--- a/Model/lib/wdk/model/records/transcriptAttributeQueries.xml
+++ b/Model/lib/wdk/model/records/transcriptAttributeQueries.xml
@@ -194,6 +194,8 @@
 
     <!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeQueriesNumeric -->
 
+    <!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeQueriesNumericByDataset -->
+
     <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
     <!-- Transcripts per gene -->
     <!-- ATTENTION: this SQL cannot be used by a boolean step because it does not have the matched_result dynamic column -->

--- a/Model/lib/wdk/model/records/transcriptRecord.xml
+++ b/Model/lib/wdk/model/records/transcriptRecord.xml
@@ -735,6 +735,8 @@
 
             <!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeRef -->
 
+            <!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeRefByDataset -->
+
 
           <attributeQueryRef ref="TranscriptAttributes.NaSequenceDatabaseName" >
             <columnAttribute name="sequence_database_name" inReportMaker="false"/>

--- a/Model/lib/wdk/model/records/transcriptRecord.xml
+++ b/Model/lib/wdk/model/records/transcriptRecord.xml
@@ -733,6 +733,8 @@
 
             <!-- TEMPLATE_ANCHOR cellularLocalizationEdaAttributeRef -->
 
+            <!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeRef -->
+
 
           <attributeQueryRef ref="TranscriptAttributes.NaSequenceDatabaseName" >
             <columnAttribute name="sequence_database_name" inReportMaker="false"/>

--- a/Model/lib/wdk/ontology/individuals.txt
+++ b/Model/lib/wdk/ontology/individuals.txt
@@ -916,6 +916,8 @@ derisi_timeseries_pie	http://purl.obolibrary.org/obo/OBI_0001985		PathwayRecordC
 ## TEMPLATE_ANCHOR profileMinMaxAttributesRnaAntisenseCategory
 ## TEMPLATE_ANCHOR phenotypeEdaAttributeCategory
 ## TEMPLATE_ANCHOR cellularLocalizationEdaAttributeCategory
+## TEMPLATE_ANCHOR antibodyArrayEdaAttributeCategory
+## TEMPLATE_ANCHOR antibodyArrayEdaAttributeCategoryByDataset
 
 ## TEMPLATE_ANCHOR metaboliteGraphTextAttributeCategory													
 ## TEMPLATE_ANCHOR graphTextAttributeCategoryPathwayRecord													


### PR DESCRIPTION
## Summary

- Add `EdaAntibodyArrayDatasets` and `EdaAntibodyArrayGraphsDataTable` SQL queries to `geneTableQueries.xml` — gene record graph table queries for EDA antibody array datasets, modeled on EDAPhenotype but without the tgonGT1 special case, filtering by `category = 'Immunology'`
- Add corresponding table definitions to `geneRecord.xml`
- Add `antibodyArrayEdaAttributeQueriesNumeric` DST template to `antibodyArray.dst` — crosstab query pivoting on `sample_stable_id` (one column per sample) via the EDA ancestor table, producing normalized intensity columns on the transcript record
- Add `antibodyArrayEdaAttributeRef`, `antibodyArrayEdaAttributeCategory`, `antibodyArrayEdaGeneTableSql`, and `antibodyArrayDataTableGeneTableSql` DST templates
- Add `<!-- TEMPLATE_ANCHOR antibodyArrayEdaAttributeRef -->` to `transcriptRecord.xml`

## Context

Antibody array EDA studies have two entity types: `Sample` (parent) and `AntbdyAr` (child). The `AntbdyAr` entity has only `VEUPATHDB_GENE_ID` and `NORMALIZED_INTENSITY` attributes. The transcript column crosstab pivots on `sample_stable_id` from the ancestor table — not on `attribute_stable_id` as Phenotype/CellularLocalization do — producing one intensity column per sample per gene.

## Test Plan

- [ ] Build and deploy to a dev site with an antibody array EDA dataset loaded
- [ ] Transcript record: normalized intensity columns appear, one per sample, grouped by dataset
- [ ] Gene record: Antibody Array Datasets table appears with graph widget and data table rows
- [ ] Confirm no sample metadata columns on transcript record
- [ ] Confirm no tgonGT1 ME49 logic fires

Companion PR: VEuPathDB/EbrcModelCommon#antibody-array-wdk-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)