### PR TITLE
Replace Oracle decode() with CASE WHEN in expression.dst

### DIFF
--- a/Model/lib/dst/expression.dst
+++ b/Model/lib/dst/expression.dst
@@ -104,7 +104,7 @@ prop=dataType
           <sql>
            <![CDATA[
 SELECT DISTINCT profile_study_id AS internal, profile_set_name AS term,
-                 decode(ps.name, '', '', ${decodeProfileSet}  '${datasetDisplayName}') as display
+                 CASE WHEN ps.name = '' THEN '' ELSE ${decodeProfileSet}  '${datasetDisplayName}' END as display
 FROM apidbtuning.profileType
 WHERE dataset_name = '${datasetName}'
 AND profile_set_name not in ( ${excludedProfileSetsList})
@@ -608,10 +608,10 @@ prop=dataType
            <![CDATA[
 	      SELECT  protocol_app_node_id as internal,
 	      CASE WHEN  ('$$channel$$' ='channel1') THEN
-                decode(protocol_app_node_name, '', '', ${channelOnePctSampleDecode}
-                       protocol_app_node_name)
-		ELSE decode(protocol_app_node_name, '', '', ${channelTwoPctSampleDecode}
-                       protocol_app_node_name)
+                CASE WHEN protocol_app_node_name = '' THEN '' ELSE ${channelOnePctSampleDecode}
+                       protocol_app_node_name END
+		ELSE CASE WHEN protocol_app_node_name = '' THEN '' ELSE ${channelTwoPctSampleDecode}
+                       protocol_app_node_name END
 		    END as term
 	      FROM apidbtuning.ProfileSamples ps
 	      WHERE ps.study_id = $$profileset_generic$$	


### PR DESCRIPTION
## Summary
- Converts 3 Oracle-specific `decode()` calls in `expression.dst` to ANSI-standard `CASE WHEN` expressions
- Affects templates `expressionPctProfileSetParamQuery` and `expressionPctSamplesParamQueryDirect`
- No logic change — `decode(col, '', '', default)` maps directly to `CASE WHEN col = '' THEN '' ELSE default END`

## Test Plan
- [ ] Verify injected WDK param queries render correctly for datasets using `ExpressionTwoChannelDirectComparison` and `ExpressionOneChannelAndReferenceDesign`
- [ ] Confirm expression profile set and percentile sample dropdowns populate as expected on a Postgres instance