### PR TITLE
PathwayEdges should not be unlogged since it is not intermediate

### DIFF
--- a/Model/lib/psql/webready/global/PathwayNodes.psql
+++ b/Model/lib/psql/webready/global/PathwayNodes.psql
@@ -191,7 +191,7 @@
 
 	DROP TABLE IF EXISTS :SCHEMA.PathwayEdges;
 	
-        CREATE UNLOGGED TABLE :SCHEMA.PathwayEdges  AS
+        CREATE TABLE :SCHEMA.PathwayEdges  AS
         SELECT pa.source_id
           , pa.pathway_source
           , rel.*


### PR DESCRIPTION
Fixes for missing rows in PathwayEdges and PathwayNodes webready tables.