### PR TITLE
Refactor TempGeneProduct and add TempTranscriptProduct

### DIFF
--- a/Model/lib/xml/tuningManager/apiTuningManager.xml
+++ b/Model/lib/xml/tuningManager/apiTuningManager.xml
@@ -17,7 +17,6 @@
             genes AS (
               SELECT gf.na_feature_id,
                      gf.source_id,
-                     gf.product,
                      o.abbrev AS org_abbrev
               FROM dots.GeneFeature gf
               INNER JOIN dots.NaSequence nas ON nas.na_sequence_id = gf.na_sequence_id
@@ -46,7 +45,8 @@
             ),
 
             informative_tp AS (
-              SELECT gf.na_feature_id AS gene_na_feature_id, tp.product, tp.assigned_by, tp.is_preferred
+              SELECT gf.na_feature_id AS gene_na_feature_id, t.na_feature_id AS transcript_na_feature_id,
+                     tp.product, tp.assigned_by, tp.is_preferred
               FROM genes gf
               INNER JOIN dots.Transcript t ON t.parent_id = gf.na_feature_id
               INNER JOIN apidb.TranscriptProduct tp ON tp.na_feature_id = t.na_feature_id
@@ -67,368 +67,138 @@
                 AND LOWER(TRIM(tp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
             ),
 
-            t1_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     1 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'veupathdb_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'veupathdb' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
+            all_informative AS (
+              SELECT na_feature_id AS gene_na_feature_id, NULL AS transcript_na_feature_id,
+                     product, assigned_by, is_preferred, 'gene' AS source_type
+              FROM informative_gfp
+              UNION ALL
+              SELECT gene_na_feature_id, transcript_na_feature_id,
+                     product, assigned_by, is_preferred, 'transcript' AS source_type
+              FROM informative_tp
             ),
-            t1_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     2 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'veupathdb_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'veupathdb' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
+
+            assigned_by_groups(assigned_by_val, group_name) AS (
+              VALUES
+                ('veupathdb',        'veupathdb'),
+                ('apollo',           'apollo'),
+                ('community',        'community'),
+                ('anderssonlab',     'lab'),
+                ('berna',            'lab'),
+                ('beverleylab',      'lab'),
+                ('corridalab',       'lab'),
+                ('flegontovlab',     'lab'),
+                ('franzen',          'lab'),
+                ('fritzlab',         'lab'),
+                ('hertzfowlerlab',   'lab'),
+                ('jcarltonlab',      'lab'),
+                ('kissingerlab',     'lab'),
+                ('liverpool',        'lab'),
+                ('lukeslab',         'lab'),
+                ('mcbridelab',       'lab'),
+                ('msu',              'lab'),
+                ('painlab',          'lab'),
+                ('requenalab',       'lab'),
+                ('siegelab',         'lab'),
+                ('stukenbrocklab',   'lab'),
+                ('tachezylab',       'lab'),
+                ('tarletonlab',      'lab'),
+                ('ubc',              'lab'),
+                ('ulaval',           'lab'),
+                ('valkiunaslab',     'lab'),
+                ('wittwerlab',       'lab'),
+                ('yurchenkolab',     'lab'),
+                ('jcvi',             'genomedb'),
+                ('jgi',              'genomedb'),
+                ('sanger',           'genomedb'),
+                ('pombase',          'genomedb'),
+                ('dictybase',        'genomedb'),
+                ('aspgd',            'genomedb'),
+                ('cgd',              'genomedb'),
+                ('sgd',              'genomedb'),
+                ('genedb',           'genomedb'),
+                ('ensembl',          'ensembl'),
+                ('uniprot',          'uniprot'),
+                ('uniprotkb/trembl', 'uniprot'),
+                ('uniprot/pfam',     'uniprot'),
+                ('refseq',           'refseq'),
+                ('entrezgene',       'entrezgene'),
+                ('genbank',          'genbank'),
+                ('gb',               'genbank'),
+                ('pfam',             'pfam'),
+                ('arba',             'arba')
             ),
-            t2_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     3 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'apollo' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
+
+            rule_lookup(group_name, is_preferred, source_type, source_rule, rule_description) AS (
+              VALUES
+                -- preferredGeneCurated (rules 1-11)
+                ('veupathdb',   1, 'gene',        1,  'veupathdb_preferred_gene'),
+                ('apollo',      1, 'gene',        2,  'apollo_preferred_gene'),
+                ('community',   1, 'gene',        3,  'community_preferred_gene'),
+                ('lab',         1, 'gene',        4,  'lab_preferred_gene'),
+                ('genomedb',    1, 'gene',        5,  'genomedb_preferred_gene'),
+                ('ensembl',     1, 'gene',        6,  'ensembl_preferred_gene'),
+                ('uniprot',     1, 'gene',        7,  'uniprot_preferred_gene'),
+                ('refseq',      1, 'gene',        8,  'refseq_preferred_gene'),
+                ('entrezgene',  1, 'gene',        9,  'entrezgene_preferred_gene'),
+                ('genbank',     1, 'gene',       10,  'genbank_preferred_gene'),
+                ('pfam',        1, 'gene',       11,  'pfam_preferred_gene'),
+                -- preferredTranscriptCurated (rules 12-22)
+                ('veupathdb',   1, 'transcript', 12,  'veupathdb_preferred_transcript'),
+                ('apollo',      1, 'transcript', 13,  'apollo_preferred_transcript'),
+                ('community',   1, 'transcript', 14,  'community_preferred_transcript'),
+                ('lab',         1, 'transcript', 15,  'lab_preferred_transcript'),
+                ('genomedb',    1, 'transcript', 16,  'genomedb_preferred_transcript'),
+                ('ensembl',     1, 'transcript', 17,  'ensembl_preferred_transcript'),
+                ('uniprot',     1, 'transcript', 18,  'uniprot_preferred_transcript'),
+                ('refseq',      1, 'transcript', 19,  'refseq_preferred_transcript'),
+                ('entrezgene',  1, 'transcript', 20,  'entrezgene_preferred_transcript'),
+                ('genbank',     1, 'transcript', 21,  'genbank_preferred_transcript'),
+                ('pfam',        1, 'transcript', 22,  'pfam_preferred_transcript'),
+                -- nonPreferredGeneCurated (rules 23-33)
+                ('veupathdb',   0, 'gene',       23,  'veupathdb_gene'),
+                ('apollo',      0, 'gene',       24,  'apollo_gene'),
+                ('community',   0, 'gene',       25,  'community_gene'),
+                ('lab',         0, 'gene',       26,  'lab_gene'),
+                ('genomedb',    0, 'gene',       27,  'genomedb_gene'),
+                ('ensembl',     0, 'gene',       28,  'ensembl_gene'),
+                ('uniprot',     0, 'gene',       29,  'uniprot_gene'),
+                ('refseq',      0, 'gene',       30,  'refseq_gene'),
+                ('entrezgene',  0, 'gene',       31,  'entrezgene_gene'),
+                ('genbank',     0, 'gene',       32,  'genbank_gene'),
+                ('pfam',        0, 'gene',       33,  'pfam_gene'),
+                -- nonPreferredTranscriptCurated (rules 34-44)
+                ('veupathdb',   0, 'transcript', 34,  'veupathdb_transcript'),
+                ('apollo',      0, 'transcript', 35,  'apollo_transcript'),
+                ('community',   0, 'transcript', 36,  'community_transcript'),
+                ('lab',         0, 'transcript', 37,  'lab_transcript'),
+                ('genomedb',    0, 'transcript', 38,  'genomedb_transcript'),
+                ('ensembl',     0, 'transcript', 39,  'ensembl_transcript'),
+                ('uniprot',     0, 'transcript', 40,  'uniprot_transcript'),
+                ('refseq',      0, 'transcript', 41,  'refseq_transcript'),
+                ('entrezgene',  0, 'transcript', 42,  'entrezgene_transcript'),
+                ('genbank',     0, 'transcript', 43,  'genbank_transcript'),
+                ('pfam',        0, 'transcript', 44,  'pfam_transcript'),
+                -- arba gene (rule 45)
+                ('arba',        0, 'gene',       45,  'arba_gene'),
+                ('arba',        1, 'gene',       45,  'arba_gene')
             ),
-            t2_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     4 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'apollo_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'apollo' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t3_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     5 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'community' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t3_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     6 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'community_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'community' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t4_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     7 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
-                                               'franzen','fritzlab','hertzfowlerlab','jcarltonlab','kissingerlab',
-                                               'liverpool','lukeslab','mcbridelab','msu','painlab','requenalab',
-                                               'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
-                                               'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
-                AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t4_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     8 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'lab_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
-                                              'franzen','fritzlab','hertzfowlerlab','jcarltonlab','kissingerlab',
-                                              'liverpool','lukeslab','mcbridelab','msu','painlab','requenalab',
-                                              'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
-                                              'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
-                AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t5_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     9 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
-                AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t5_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     10 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genomedb_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
-                AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t6_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     11 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'ensembl' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t6_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     12 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'ensembl_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'ensembl' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t7_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     13 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
-                AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t7_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     14 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'uniprot_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
-                AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t8_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     15 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'refseq' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t8_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     16 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'refseq_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'refseq' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t9_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     17 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'entrezgene' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t9_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     18 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'entrezgene_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'entrezgene' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t10_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     19 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('genbank','gb') AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t10_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     20 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genbank_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('genbank','gb') AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t11_pref_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     21 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_preferred_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'pfam' AND igfp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t11_pref_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     22 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'pfam_preferred_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'pfam' AND itp.is_preferred = 1
-              GROUP BY gf.source_id
-            ),
-            t1_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     23 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'veupathdb_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'veupathdb'
-              GROUP BY gf.source_id
-            ),
-            t1_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     24 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'veupathdb_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'veupathdb'
-              GROUP BY gf.source_id
-            ),
-            t2_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     25 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'apollo'
-              GROUP BY gf.source_id
-            ),
-            t2_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     26 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'apollo_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'apollo'
-              GROUP BY gf.source_id
-            ),
-            t3_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     27 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'community'
-              GROUP BY gf.source_id
-            ),
-            t3_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     28 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'community_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'community'
-              GROUP BY gf.source_id
-            ),
-            t4_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     29 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
-                                               'franzen','fritzlab','hertzfowlerlab','jcarltonlab','kissingerlab',
-                                               'liverpool','lukeslab','mcbridelab','msu','painlab','requenalab',
-                                               'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
-                                               'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
-              GROUP BY gf.source_id
-            ),
-            t4_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     30 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'lab_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
-                                              'franzen','fritzlab','hertzfowlerlab','jcarltonlab','kissingerlab',
-                                              'liverpool','lukeslab','mcbridelab','msu','painlab','requenalab',
-                                              'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
-                                              'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
-              GROUP BY gf.source_id
-            ),
-            t5_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     31 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
-              GROUP BY gf.source_id
-            ),
-            t5_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     32 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genomedb_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
-              GROUP BY gf.source_id
-            ),
-            t6_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     33 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'ensembl'
-              GROUP BY gf.source_id
-            ),
-            t6_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     34 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'ensembl_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'ensembl'
-              GROUP BY gf.source_id
-            ),
-            t7_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     35 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
-              GROUP BY gf.source_id
-            ),
-            t7_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     36 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'uniprot_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
-              GROUP BY gf.source_id
-            ),
-            t8_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     37 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'refseq'
-              GROUP BY gf.source_id
-            ),
-            t8_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     38 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'refseq_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'refseq'
-              GROUP BY gf.source_id
-            ),
-            t9_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     39 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'entrezgene'
-              GROUP BY gf.source_id
-            ),
-            t9_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     40 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'entrezgene_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'entrezgene'
-              GROUP BY gf.source_id
-            ),
-            t10_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     41 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) IN ('genbank','gb')
-              GROUP BY gf.source_id
-            ),
-            t10_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     42 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genbank_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) IN ('genbank','gb')
-              GROUP BY gf.source_id
-            ),
-            t11_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     43 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'pfam'
-              GROUP BY gf.source_id
-            ),
-            t11_transcript AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-                     44 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'pfam_transcript' AS rule_description
-              FROM genes gf INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-              WHERE LOWER(itp.assigned_by) = 'pfam'
-              GROUP BY gf.source_id
-            ),
-            arba_gene AS (
-              SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-                     45 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'arba_gene' AS rule_description
-              FROM genes gf INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-              WHERE LOWER(igfp.assigned_by) = 'arba'
-              GROUP BY gf.source_id
-            ),
+
             all_products AS (
-              SELECT * FROM t1_pref_gene    UNION ALL SELECT * FROM t1_pref_transcript
-              UNION ALL SELECT * FROM t2_pref_gene    UNION ALL SELECT * FROM t2_pref_transcript
-              UNION ALL SELECT * FROM t3_pref_gene    UNION ALL SELECT * FROM t3_pref_transcript
-              UNION ALL SELECT * FROM t4_pref_gene    UNION ALL SELECT * FROM t4_pref_transcript
-              UNION ALL SELECT * FROM t5_pref_gene    UNION ALL SELECT * FROM t5_pref_transcript
-              UNION ALL SELECT * FROM t6_pref_gene    UNION ALL SELECT * FROM t6_pref_transcript
-              UNION ALL SELECT * FROM t7_pref_gene    UNION ALL SELECT * FROM t7_pref_transcript
-              UNION ALL SELECT * FROM t8_pref_gene    UNION ALL SELECT * FROM t8_pref_transcript
-              UNION ALL SELECT * FROM t9_pref_gene    UNION ALL SELECT * FROM t9_pref_transcript
-              UNION ALL SELECT * FROM t10_pref_gene   UNION ALL SELECT * FROM t10_pref_transcript
-              UNION ALL SELECT * FROM t11_pref_gene   UNION ALL SELECT * FROM t11_pref_transcript
-              UNION ALL SELECT * FROM t1_gene         UNION ALL SELECT * FROM t1_transcript
-              UNION ALL SELECT * FROM t2_gene         UNION ALL SELECT * FROM t2_transcript
-              UNION ALL SELECT * FROM t3_gene         UNION ALL SELECT * FROM t3_transcript
-              UNION ALL SELECT * FROM t4_gene         UNION ALL SELECT * FROM t4_transcript
-              UNION ALL SELECT * FROM t5_gene         UNION ALL SELECT * FROM t5_transcript
-              UNION ALL SELECT * FROM t6_gene         UNION ALL SELECT * FROM t6_transcript
-              UNION ALL SELECT * FROM t7_gene         UNION ALL SELECT * FROM t7_transcript
-              UNION ALL SELECT * FROM t8_gene         UNION ALL SELECT * FROM t8_transcript
-              UNION ALL SELECT * FROM t9_gene         UNION ALL SELECT * FROM t9_transcript
-              UNION ALL SELECT * FROM t10_gene        UNION ALL SELECT * FROM t10_transcript
-              UNION ALL SELECT * FROM t11_gene        UNION ALL SELECT * FROM t11_transcript
-              UNION ALL SELECT * FROM arba_gene
+              SELECT gf.source_id,
+                     SUBSTR(STRING_AGG(DISTINCT ai.product, ', ' ORDER BY ai.product), 1, 4000) AS product,
+                     rl.source_rule,
+                     COUNT(DISTINCT ai.product) AS value_count,
+                     rl.rule_description
+              FROM genes gf
+              INNER JOIN all_informative ai ON ai.gene_na_feature_id = gf.na_feature_id
+              INNER JOIN assigned_by_groups abg ON abg.assigned_by_val = LOWER(ai.assigned_by)
+              INNER JOIN rule_lookup rl ON rl.group_name = abg.group_name
+                                       AND rl.is_preferred = ai.is_preferred
+                                       AND rl.source_type = ai.source_type
+              GROUP BY gf.source_id, rl.source_rule, rl.rule_description, rl.source_type
+              HAVING rl.source_type = 'gene' OR COUNT(DISTINCT ai.transcript_na_feature_id) = 1
             ),
+
             ranked_products AS (
               SELECT source_id, product, source_rule, value_count, rule_description,
                      ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY source_rule) AS rank
@@ -453,6 +223,235 @@
     <sql>
       <![CDATA[
         CREATE INDEX ON TempGeneProduct&1 (org_abbrev, source_id)
+      ]]>
+    </sql>
+  </tuningTable>
+
+  <tuningTable name="TempTranscriptProduct">
+    <externalDependency name="dots.GeneFeature"/>
+    <externalDependency name="dots.NaSequence"/>
+    <externalDependency name="apidb.Organism"/>
+    <externalDependency name="dots.Transcript"/>
+    <externalDependency name="apidb.GeneFeatureProduct"/>
+    <externalDependency name="apidb.TranscriptProduct"/>
+    <sql>
+      <![CDATA[
+        CREATE TABLE TempTranscriptProduct&1 AS
+        WITH
+            genes AS (
+              SELECT gf.na_feature_id,
+                     gf.source_id,
+                     o.abbrev AS org_abbrev
+              FROM dots.GeneFeature gf
+              INNER JOIN dots.NaSequence nas ON nas.na_sequence_id = gf.na_sequence_id
+              INNER JOIN apidb.Organism o ON o.taxon_id = nas.taxon_id
+            ),
+
+            transcripts AS (
+              SELECT t.na_feature_id  AS transcript_na_feature_id,
+                     t.source_id      AS transcript_source_id,
+                     gf.na_feature_id AS gene_na_feature_id,
+                     gf.org_abbrev
+              FROM genes gf
+              INNER JOIN dots.Transcript t ON t.parent_id = gf.na_feature_id
+            ),
+
+            informative_gfp AS (
+              SELECT gfp.na_feature_id AS gene_na_feature_id, gfp.product, gfp.assigned_by, gfp.is_preferred
+              FROM genes gf
+              INNER JOIN apidb.GeneFeatureProduct gfp ON gfp.na_feature_id = gf.na_feature_id
+              WHERE gfp.product IS NOT NULL
+                AND TRIM(gfp.product) != ''
+                AND gfp.product !~* '(hypothetical[_ ]protein|unspecified product|conserved hypothetical protein|predicted protein|protein of unknown function|uncharacterized protein|conserved protein,\s*unknown function|---na---|contig)'
+                AND NOT (gfp.product ~* '^has domain\(s\) with predicted' AND (gfp.product LIKE '%,%' OR gfp.product ~* ' and '))
+                AND NOT (gfp.product NOT LIKE '% %' AND gfp.product LIKE 'XM%')
+                AND gfp.product !~ '^CAD\d+(\.\d+)?$'
+                AND gfp.product !~* 'conserved\s+\w+\s+protein,?\s*unknown\s+function'
+                AND gfp.product !~* 'uncharacterized\s+loc\d+'
+                AND gfp.product NOT LIKE 'CSON%'
+                AND gfp.product NOT LIKE 'hypothetical protein BGH%'
+                AND gfp.product NOT LIKE 'DEHA2A%'
+                AND NOT (gfp.product NOT LIKE '% %' AND (gfp.product ~ '^[A-Z]{2,4}\d{4,}$' OR gfp.product ~ '^[A-Z]{3,5}_\d+$' OR gfp.product ~ '^LOC\d+$' OR gfp.product ~ '^[A-Z]+\d+\.[0-9]+$'))
+                AND gfp.product NOT LIKE 'Similar to [%'
+                AND gfp.product NOT LIKE '%UniProtKB%'
+                AND LOWER(TRIM(gfp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
+            ),
+
+            informative_tp AS (
+              SELECT tp.na_feature_id AS transcript_na_feature_id, tp.product, tp.assigned_by, tp.is_preferred
+              FROM transcripts tr
+              INNER JOIN apidb.TranscriptProduct tp ON tp.na_feature_id = tr.transcript_na_feature_id
+              WHERE tp.product IS NOT NULL
+                AND TRIM(tp.product) != ''
+                AND tp.product !~* '(hypothetical[_ ]protein|unspecified product|conserved hypothetical protein|predicted protein|protein of unknown function|uncharacterized protein|conserved protein,\s*unknown function|---na---|contig)'
+                AND NOT (tp.product ~* '^has domain\(s\) with predicted' AND (tp.product LIKE '%,%' OR tp.product ~* ' and '))
+                AND NOT (tp.product NOT LIKE '% %' AND tp.product LIKE 'XM%')
+                AND tp.product !~ '^CAD\d+(\.\d+)?$'
+                AND tp.product !~* 'conserved\s+\w+\s+protein,?\s*unknown\s+function'
+                AND tp.product !~* 'uncharacterized\s+loc\d+'
+                AND tp.product NOT LIKE 'CSON%'
+                AND tp.product NOT LIKE 'hypothetical protein BGH%'
+                AND tp.product NOT LIKE 'DEHA2A%'
+                AND NOT (tp.product NOT LIKE '% %' AND (tp.product ~ '^[A-Z]{2,4}\d{4,}$' OR tp.product ~ '^[A-Z]{3,5}_\d+$' OR tp.product ~ '^LOC\d+$' OR tp.product ~ '^[A-Z]+\d+\.[0-9]+$'))
+                AND tp.product NOT LIKE 'Similar to [%'
+                AND tp.product NOT LIKE '%UniProtKB%'
+                AND LOWER(TRIM(tp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
+            ),
+
+            all_informative AS (
+              SELECT tr.transcript_source_id AS source_id, itp.product, itp.assigned_by, itp.is_preferred, 'transcript' AS source_type
+              FROM transcripts tr
+              INNER JOIN informative_tp itp ON itp.transcript_na_feature_id = tr.transcript_na_feature_id
+              UNION ALL
+              SELECT tr.transcript_source_id AS source_id, igfp.product, igfp.assigned_by, igfp.is_preferred, 'gene' AS source_type
+              FROM transcripts tr
+              INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = tr.gene_na_feature_id
+            ),
+
+            assigned_by_groups(assigned_by_val, group_name) AS (
+              VALUES
+                ('veupathdb',        'veupathdb'),
+                ('apollo',           'apollo'),
+                ('community',        'community'),
+                ('anderssonlab',     'lab'),
+                ('berna',            'lab'),
+                ('beverleylab',      'lab'),
+                ('corridalab',       'lab'),
+                ('flegontovlab',     'lab'),
+                ('franzen',          'lab'),
+                ('fritzlab',         'lab'),
+                ('hertzfowlerlab',   'lab'),
+                ('jcarltonlab',      'lab'),
+                ('kissingerlab',     'lab'),
+                ('liverpool',        'lab'),
+                ('lukeslab',         'lab'),
+                ('mcbridelab',       'lab'),
+                ('msu',              'lab'),
+                ('painlab',          'lab'),
+                ('requenalab',       'lab'),
+                ('siegelab',         'lab'),
+                ('stukenbrocklab',   'lab'),
+                ('tachezylab',       'lab'),
+                ('tarletonlab',      'lab'),
+                ('ubc',              'lab'),
+                ('ulaval',           'lab'),
+                ('valkiunaslab',     'lab'),
+                ('wittwerlab',       'lab'),
+                ('yurchenkolab',     'lab'),
+                ('jcvi',             'genomedb'),
+                ('jgi',              'genomedb'),
+                ('sanger',           'genomedb'),
+                ('pombase',          'genomedb'),
+                ('dictybase',        'genomedb'),
+                ('aspgd',            'genomedb'),
+                ('cgd',              'genomedb'),
+                ('sgd',              'genomedb'),
+                ('genedb',           'genomedb'),
+                ('ensembl',          'ensembl'),
+                ('uniprot',          'uniprot'),
+                ('uniprotkb/trembl', 'uniprot'),
+                ('uniprot/pfam',     'uniprot'),
+                ('refseq',           'refseq'),
+                ('entrezgene',       'entrezgene'),
+                ('genbank',          'genbank'),
+                ('gb',               'genbank'),
+                ('pfam',             'pfam'),
+                ('arba',             'arba')
+            ),
+
+            rule_lookup(group_name, is_preferred, source_type, source_rule, rule_description) AS (
+              VALUES
+                -- preferredTranscriptCurated (rules 1-11)
+                ('veupathdb',   1, 'transcript',  1,  'veupathdb_preferred_transcript'),
+                ('apollo',      1, 'transcript',  2,  'apollo_preferred_transcript'),
+                ('community',   1, 'transcript',  3,  'community_preferred_transcript'),
+                ('lab',         1, 'transcript',  4,  'lab_preferred_transcript'),
+                ('genomedb',    1, 'transcript',  5,  'genomedb_preferred_transcript'),
+                ('ensembl',     1, 'transcript',  6,  'ensembl_preferred_transcript'),
+                ('uniprot',     1, 'transcript',  7,  'uniprot_preferred_transcript'),
+                ('refseq',      1, 'transcript',  8,  'refseq_preferred_transcript'),
+                ('entrezgene',  1, 'transcript',  9,  'entrezgene_preferred_transcript'),
+                ('genbank',     1, 'transcript', 10,  'genbank_preferred_transcript'),
+                ('pfam',        1, 'transcript', 11,  'pfam_preferred_transcript'),
+                -- nonPreferredTranscriptCurated (rules 12-22)
+                ('veupathdb',   0, 'transcript', 12,  'veupathdb_transcript'),
+                ('apollo',      0, 'transcript', 13,  'apollo_transcript'),
+                ('community',   0, 'transcript', 14,  'community_transcript'),
+                ('lab',         0, 'transcript', 15,  'lab_transcript'),
+                ('genomedb',    0, 'transcript', 16,  'genomedb_transcript'),
+                ('ensembl',     0, 'transcript', 17,  'ensembl_transcript'),
+                ('uniprot',     0, 'transcript', 18,  'uniprot_transcript'),
+                ('refseq',      0, 'transcript', 19,  'refseq_transcript'),
+                ('entrezgene',  0, 'transcript', 20,  'entrezgene_transcript'),
+                ('genbank',     0, 'transcript', 21,  'genbank_transcript'),
+                ('pfam',        0, 'transcript', 22,  'pfam_transcript'),
+                -- preferredGeneCurated (rules 23-33)
+                ('veupathdb',   1, 'gene',       23,  'veupathdb_preferred_gene'),
+                ('apollo',      1, 'gene',       24,  'apollo_preferred_gene'),
+                ('community',   1, 'gene',       25,  'community_preferred_gene'),
+                ('lab',         1, 'gene',       26,  'lab_preferred_gene'),
+                ('genomedb',    1, 'gene',       27,  'genomedb_preferred_gene'),
+                ('ensembl',     1, 'gene',       28,  'ensembl_preferred_gene'),
+                ('uniprot',     1, 'gene',       29,  'uniprot_preferred_gene'),
+                ('refseq',      1, 'gene',       30,  'refseq_preferred_gene'),
+                ('entrezgene',  1, 'gene',       31,  'entrezgene_preferred_gene'),
+                ('genbank',     1, 'gene',       32,  'genbank_preferred_gene'),
+                ('pfam',        1, 'gene',       33,  'pfam_preferred_gene'),
+                -- nonPreferredGeneCurated (rules 34-44)
+                ('veupathdb',   0, 'gene',       34,  'veupathdb_gene'),
+                ('apollo',      0, 'gene',       35,  'apollo_gene'),
+                ('community',   0, 'gene',       36,  'community_gene'),
+                ('lab',         0, 'gene',       37,  'lab_gene'),
+                ('genomedb',    0, 'gene',       38,  'genomedb_gene'),
+                ('ensembl',     0, 'gene',       39,  'ensembl_gene'),
+                ('uniprot',     0, 'gene',       40,  'uniprot_gene'),
+                ('refseq',      0, 'gene',       41,  'refseq_gene'),
+                ('entrezgene',  0, 'gene',       42,  'entrezgene_gene'),
+                ('genbank',     0, 'gene',       43,  'genbank_gene'),
+                ('pfam',        0, 'gene',       44,  'pfam_gene'),
+                -- arba gene (rule 45)
+                ('arba',        0, 'gene',       45,  'arba_gene'),
+                ('arba',        1, 'gene',       45,  'arba_gene')
+            ),
+
+            all_products AS (
+              SELECT ai.source_id,
+                     SUBSTR(STRING_AGG(DISTINCT ai.product, ', ' ORDER BY ai.product), 1, 4000) AS product,
+                     rl.source_rule,
+                     COUNT(DISTINCT ai.product) AS value_count,
+                     rl.rule_description
+              FROM all_informative ai
+              INNER JOIN assigned_by_groups abg ON abg.assigned_by_val = LOWER(ai.assigned_by)
+              INNER JOIN rule_lookup rl ON rl.group_name = abg.group_name
+                                       AND rl.is_preferred = ai.is_preferred
+                                       AND rl.source_type = ai.source_type
+              GROUP BY ai.source_id, rl.source_rule, rl.rule_description
+            ),
+
+            ranked_products AS (
+              SELECT source_id, product, source_rule, value_count, rule_description,
+                     ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY source_rule) AS rank
+              FROM all_products
+            )
+        SELECT tr.transcript_source_id                      AS source_id,
+               COALESCE(rp.product, 'unspecified product')  AS product,
+               COALESCE(rp.value_count, 0)                  AS value_count,
+               COALESCE(rp.source_rule, 46)                 AS source_rule,
+               COALESCE(rp.rule_description, 'unspecified') AS source_rule_description,
+               tr.org_abbrev,
+               current_timestamp                            AS modification_date
+        FROM transcripts tr
+        LEFT JOIN ranked_products rp ON rp.source_id = tr.transcript_source_id AND rp.rank = 1
+      ]]>
+    </sql>
+    <sql>
+      <![CDATA[
+        CREATE INDEX ON TempTranscriptProduct&1 (source_id)
+      ]]>
+    </sql>
+    <sql>
+      <![CDATA[
+        CREATE INDEX ON TempTranscriptProduct&1 (org_abbrev, source_id)
       ]]>
     </sql>
   </tuningTable>
@@ -501,7 +500,7 @@
  <tuningTable name="TranscriptAttributes">
     <externalDependency name="webready.TranscriptAttributes_p"/>
     <internalDependency name="TempGeneProduct"/>
-    <!--externalDependency name="webready.TranscriptProduct_p"/-->
+    <internalDependency name="TempTranscriptProduct"/>
     <sql>
       <![CDATA[
        create table transcriptattributes&1 as select * from webready.transcriptattributes_p;
@@ -516,15 +515,15 @@
           AND gp.product IS NOT NULL
       ]]>
     </sql>
-    <!--sql>
+    <sql>
       <![CDATA[
         UPDATE transcriptattributes&1 ta
         SET transcript_product = tp.product
-        FROM webready.TranscriptProduct_p tp
+        FROM TempTranscriptProduct tp
         WHERE ta.source_id = tp.source_id
           AND tp.product IS NOT NULL
       ]]>
-    </sql-->
+    </sql>
     <sql>
       <![CDATA[
         CREATE UNIQUE INDEX transcriptattr_sourceId&1 ON TranscriptAttributes&1  (source_id);


### PR DESCRIPTION
## Summary

- Replaces 45 near-identical CTEs in `TempGeneProduct` with `assigned_by_groups` + `rule_lookup` VALUES lookup tables — same logic, ~350 fewer lines
- Reorders `TempGeneProduct` ranking hierarchy: all preferredGeneCurated (1–11) → preferredTranscriptCurated (12–22) → nonPreferredGeneCurated (23–33) → nonPreferredTranscriptCurated (34–44) → arba (45)
- For multi-transcript genes, transcript-level tiers are only used when a single transcript is the sole contributor at that tier (multiple transcripts may contribute multiple products from the same transcript; two different transcripts contributing at the same tier causes that tier to be skipped)
- Adds `TempTranscriptProduct` (transcript-keyed) with the inverse ranking order: preferredTranscriptCurated first, gene tiers as fallback
- Updates `TranscriptAttributes` to populate `transcript_product` from `TempTranscriptProduct` (joining on transcript `source_id`)

## Test plan

- [ ] Run tuning for a representative organism and verify `TempGeneProduct.source_rule_description` values match expected tier labels
- [ ] Verify `TempTranscriptProduct` is populated and keyed on transcript `source_id`
- [ ] Confirm `TranscriptAttributes.gene_product` and `transcript_product` are both populated after tuning
- [ ] Spot-check a multi-transcript gene where transcripts have different products — confirm transcript tiers are skipped in `TempGeneProduct`
- [ ] Spot-check a multi-transcript gene where one transcript has multiple products — confirm that tier is included and products are concatenated

🤖 Generated with [Claude Code](https://claude.ai/claude-code)