### PR TITLE
Align GeneProduct_p and TranscriptProduct_p with new TempGeneProduct/…

### DIFF
--- a/Model/lib/psql/webready/orgSpecific/GeneProduct_p.psql
+++ b/Model/lib/psql/webready/orgSpecific/GeneProduct_p.psql
@@ -32,13 +32,15 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
         AND gfp.product NOT LIKE 'DEHA2A%'
         AND NOT (gfp.product NOT LIKE '% %' AND (gfp.product ~ '^[A-Z]{2,4}\d{4,}$' OR gfp.product ~ '^[A-Z]{3,5}_\d+$' OR gfp.product ~ '^LOC\d+$' OR gfp.product ~ '^[A-Z]+\d+\.[0-9]+$'))
         AND gfp.product NOT LIKE 'Similar to [%'
-        AND gfp.product NOT LIKE '%Source:UniProt%'
+        AND gfp.product NOT LIKE '%UniProtKB%'
         AND LOWER(TRIM(gfp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
     ),
 
     -- Informative transcript products (uninformative products excluded)
+    -- transcript_na_feature_id tracked to enforce 1-distinct-transcript constraint per gene
     informative_tp AS (
-      SELECT gf.na_feature_id as gene_na_feature_id, tp.product, tp.assigned_by, tp.is_preferred
+      SELECT gf.na_feature_id AS gene_na_feature_id, t.na_feature_id AS transcript_na_feature_id,
+             tp.product, tp.assigned_by, tp.is_preferred
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN dots.Transcript t ON t.parent_id = gf.na_feature_id
       INNER JOIN apidb.TranscriptProduct tp ON tp.na_feature_id = t.na_feature_id
@@ -55,15 +57,14 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
         AND tp.product NOT LIKE 'DEHA2A%'
         AND NOT (tp.product NOT LIKE '% %' AND (tp.product ~ '^[A-Z]{2,4}\d{4,}$' OR tp.product ~ '^[A-Z]{3,5}_\d+$' OR tp.product ~ '^LOC\d+$' OR tp.product ~ '^[A-Z]+\d+\.[0-9]+$'))
         AND tp.product NOT LIKE 'Similar to [%'
-        AND tp.product NOT LIKE '%Source:UniProt%'
+        AND tp.product NOT LIKE '%UniProtKB%'
         AND LOWER(TRIM(tp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
     ),
 
     -- ===========================================================
-    -- Pass 1: Preferred products, walking tier hierarchy (GFP then TP per tier)
+    -- Pass 1: Preferred GFP, all tiers (rules 1-11)
     -- ===========================================================
 
-    -- Tier 1 (VEuPathDB) preferred
     t1_pref_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
              1 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'veupathdb_preferred_gene' AS rule_description
@@ -72,55 +73,25 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
       WHERE LOWER(igfp.assigned_by) = 'veupathdb' AND igfp.is_preferred = 1
       GROUP BY gf.source_id
     ),
-    t1_pref_transcript AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             2 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'veupathdb_preferred_transcript' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-      WHERE LOWER(itp.assigned_by) = 'veupathdb' AND itp.is_preferred = 1
-      GROUP BY gf.source_id
-    ),
-
-    -- Tier 2 (Apollo) preferred
     t2_pref_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             3 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_preferred_gene' AS rule_description
+             2 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_preferred_gene' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
       WHERE LOWER(igfp.assigned_by) = 'apollo' AND igfp.is_preferred = 1
       GROUP BY gf.source_id
     ),
-    t2_pref_transcript AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             4 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'apollo_preferred_transcript' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-      WHERE LOWER(itp.assigned_by) = 'apollo' AND itp.is_preferred = 1
-      GROUP BY gf.source_id
-    ),
-
-    -- Tier 3 (Community) preferred
     t3_pref_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             5 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_preferred_gene' AS rule_description
+             3 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_preferred_gene' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
       WHERE LOWER(igfp.assigned_by) = 'community' AND igfp.is_preferred = 1
       GROUP BY gf.source_id
     ),
-    t3_pref_transcript AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             6 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'community_preferred_transcript' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-      WHERE LOWER(itp.assigned_by) = 'community' AND itp.is_preferred = 1
-      GROUP BY gf.source_id
-    ),
-
-    -- Tier 4 (Research Labs) preferred
     t4_pref_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             7 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_preferred_gene' AS rule_description
+             4 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_preferred_gene' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
       WHERE LOWER(igfp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
@@ -131,9 +102,100 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
         AND igfp.is_preferred = 1
       GROUP BY gf.source_id
     ),
+    t5_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             5 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
+        AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+    t6_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             6 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'ensembl' AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+    t7_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             7 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
+        AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+    t8_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             8 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'refseq' AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+    t9_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             9 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'entrezgene' AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+    t10_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             10 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('genbank','gb') AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+    t11_pref_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             11 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'pfam' AND igfp.is_preferred = 1
+      GROUP BY gf.source_id
+    ),
+
+    -- ===========================================================
+    -- Pass 2: Preferred TP, all tiers (rules 12-22)
+    -- Only included when exactly 1 distinct transcript contributes
+    -- ===========================================================
+
+    t1_pref_transcript AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
+             12 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'veupathdb_preferred_transcript' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
+      WHERE LOWER(itp.assigned_by) = 'veupathdb' AND itp.is_preferred = 1
+      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
+    ),
+    t2_pref_transcript AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
+             13 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'apollo_preferred_transcript' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
+      WHERE LOWER(itp.assigned_by) = 'apollo' AND itp.is_preferred = 1
+      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
+    ),
+    t3_pref_transcript AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
+             14 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'community_preferred_transcript' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
+      WHERE LOWER(itp.assigned_by) = 'community' AND itp.is_preferred = 1
+      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
+    ),
     t4_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             8 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'lab_preferred_transcript' AS rule_description
+             15 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'lab_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
@@ -143,128 +205,63 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
                                         'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
         AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 5 (Genome DBs: JCVI, JGI, Sanger, PomBase, dictyBase, AspGD, CGD, SGD, GeneDB) preferred
-    t5_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             9 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
-        AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t5_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             10 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genomedb_preferred_transcript' AS rule_description
+             16 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genomedb_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
         AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 6 (Ensembl) preferred
-    t6_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             11 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'ensembl' AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t6_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             12 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'ensembl_preferred_transcript' AS rule_description
+             17 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'ensembl_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'ensembl' AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 7 (UniProt) preferred
-    t7_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             13 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
-        AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t7_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             14 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'uniprot_preferred_transcript' AS rule_description
+             18 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'uniprot_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
         AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 8 (RefSeq) preferred
-    t8_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             15 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'refseq' AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t8_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             16 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'refseq_preferred_transcript' AS rule_description
+             19 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'refseq_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'refseq' AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 9 (EntrezGene) preferred
-    t9_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             17 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'entrezgene' AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t9_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             18 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'entrezgene_preferred_transcript' AS rule_description
+             20 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'entrezgene_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'entrezgene' AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 10 (GenBank) preferred
-    t10_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             19 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) IN ('genbank','gb') AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t10_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             20 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genbank_preferred_transcript' AS rule_description
+             21 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genbank_preferred_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('genbank','gb') AND itp.is_preferred = 1
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 11 (Pfam) preferred
-    t11_pref_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             21 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_preferred_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'pfam' AND igfp.is_preferred = 1
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t11_pref_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
@@ -273,13 +270,13 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'pfam' AND itp.is_preferred = 1
       GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
 
     -- ===========================================================
-    -- Pass 2: Non-preferred products, walking tier hierarchy (GFP then TP per tier)
+    -- Pass 3: Non-preferred GFP, all tiers (rules 23-33)
     -- ===========================================================
 
-    -- Tier 1 (VEuPathDB) non-preferred
     t1_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
              23 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'veupathdb_gene' AS rule_description
@@ -288,55 +285,25 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
       WHERE LOWER(igfp.assigned_by) = 'veupathdb'
       GROUP BY gf.source_id
     ),
-    t1_transcript AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             24 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'veupathdb_transcript' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-      WHERE LOWER(itp.assigned_by) = 'veupathdb'
-      GROUP BY gf.source_id
-    ),
-
-    -- Tier 2 (Apollo) non-preferred
     t2_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             25 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_gene' AS rule_description
+             24 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_gene' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
       WHERE LOWER(igfp.assigned_by) = 'apollo'
       GROUP BY gf.source_id
     ),
-    t2_transcript AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             26 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'apollo_transcript' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-      WHERE LOWER(itp.assigned_by) = 'apollo'
-      GROUP BY gf.source_id
-    ),
-
-    -- Tier 3 (Community) non-preferred
     t3_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             27 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_gene' AS rule_description
+             25 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_gene' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
       WHERE LOWER(igfp.assigned_by) = 'community'
       GROUP BY gf.source_id
     ),
-    t3_transcript AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             28 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'community_transcript' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
-      WHERE LOWER(itp.assigned_by) = 'community'
-      GROUP BY gf.source_id
-    ),
-
-    -- Tier 4 (Research Labs) non-preferred
     t4_gene AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             29 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_gene' AS rule_description
+             26 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_gene' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
       WHERE LOWER(igfp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
@@ -346,9 +313,98 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
                                          'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
       GROUP BY gf.source_id
     ),
+    t5_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             27 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
+      GROUP BY gf.source_id
+    ),
+    t6_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             28 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'ensembl'
+      GROUP BY gf.source_id
+    ),
+    t7_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             29 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
+      GROUP BY gf.source_id
+    ),
+    t8_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             30 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'refseq'
+      GROUP BY gf.source_id
+    ),
+    t9_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             31 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'entrezgene'
+      GROUP BY gf.source_id
+    ),
+    t10_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             32 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('genbank','gb')
+      GROUP BY gf.source_id
+    ),
+    t11_gene AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             33 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'pfam'
+      GROUP BY gf.source_id
+    ),
+
+    -- ===========================================================
+    -- Pass 4: Non-preferred TP, all tiers (rules 34-44)
+    -- Only included when exactly 1 distinct transcript contributes
+    -- ===========================================================
+
+    t1_transcript AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
+             34 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'veupathdb_transcript' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
+      WHERE LOWER(itp.assigned_by) = 'veupathdb'
+      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
+    ),
+    t2_transcript AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
+             35 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'apollo_transcript' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
+      WHERE LOWER(itp.assigned_by) = 'apollo'
+      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
+    ),
+    t3_transcript AS (
+      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
+             36 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'community_transcript' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
+      INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
+      WHERE LOWER(itp.assigned_by) = 'community'
+      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
+    ),
     t4_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             30 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'lab_transcript' AS rule_description
+             37 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'lab_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
@@ -357,124 +413,61 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
                                         'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
                                         'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 5 (Genome DBs) non-preferred
-    t5_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             31 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t5_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             32 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genomedb_transcript' AS rule_description
+             38 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genomedb_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 6 (Ensembl) non-preferred
-    t6_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             33 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'ensembl'
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t6_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             34 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'ensembl_transcript' AS rule_description
+             39 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'ensembl_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'ensembl'
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 7 (UniProt) non-preferred
-    t7_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             35 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t7_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             36 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'uniprot_transcript' AS rule_description
+             40 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'uniprot_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 8 (RefSeq) non-preferred
-    t8_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             37 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'refseq'
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t8_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             38 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'refseq_transcript' AS rule_description
+             41 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'refseq_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'refseq'
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 9 (EntrezGene) non-preferred
-    t9_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             39 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'entrezgene'
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t9_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             40 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'entrezgene_transcript' AS rule_description
+             42 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'entrezgene_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'entrezgene'
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 10 (GenBank) non-preferred
-    t10_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             41 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) IN ('genbank','gb')
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t10_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
-             42 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genbank_transcript' AS rule_description
+             43 AS source_rule, COUNT(DISTINCT itp.product) AS value_count, 'genbank_transcript' AS rule_description
       FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) IN ('genbank','gb')
       GROUP BY gf.source_id
-    ),
-
-    -- Tier 11 (Pfam) non-preferred
-    t11_gene AS (
-      SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
-             43 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_gene' AS rule_description
-      FROM :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp gf
-      INNER JOIN informative_gfp igfp ON igfp.na_feature_id = gf.na_feature_id
-      WHERE LOWER(igfp.assigned_by) = 'pfam'
-      GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
     t11_transcript AS (
       SELECT gf.source_id, SUBSTR(STRING_AGG(DISTINCT itp.product, ', ' ORDER BY itp.product), 1, 4000) AS product,
@@ -483,6 +476,7 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
       INNER JOIN informative_tp itp ON itp.gene_na_feature_id = gf.na_feature_id
       WHERE LOWER(itp.assigned_by) = 'pfam'
       GROUP BY gf.source_id
+      HAVING COUNT(DISTINCT itp.transcript_na_feature_id) = 1
     ),
 
     -- ===========================================================
@@ -498,28 +492,30 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVGeneFeatureProductTmp as
     ),
 
     all_products AS (
-      SELECT * FROM t1_pref_gene    UNION ALL SELECT * FROM t1_pref_transcript
-      UNION ALL SELECT * FROM t2_pref_gene    UNION ALL SELECT * FROM t2_pref_transcript
-      UNION ALL SELECT * FROM t3_pref_gene    UNION ALL SELECT * FROM t3_pref_transcript
-      UNION ALL SELECT * FROM t4_pref_gene    UNION ALL SELECT * FROM t4_pref_transcript
-      UNION ALL SELECT * FROM t5_pref_gene    UNION ALL SELECT * FROM t5_pref_transcript
-      UNION ALL SELECT * FROM t6_pref_gene    UNION ALL SELECT * FROM t6_pref_transcript
-      UNION ALL SELECT * FROM t7_pref_gene    UNION ALL SELECT * FROM t7_pref_transcript
-      UNION ALL SELECT * FROM t8_pref_gene    UNION ALL SELECT * FROM t8_pref_transcript
-      UNION ALL SELECT * FROM t9_pref_gene    UNION ALL SELECT * FROM t9_pref_transcript
-      UNION ALL SELECT * FROM t10_pref_gene   UNION ALL SELECT * FROM t10_pref_transcript
-      UNION ALL SELECT * FROM t11_pref_gene   UNION ALL SELECT * FROM t11_pref_transcript
-      UNION ALL SELECT * FROM t1_gene         UNION ALL SELECT * FROM t1_transcript
-      UNION ALL SELECT * FROM t2_gene         UNION ALL SELECT * FROM t2_transcript
-      UNION ALL SELECT * FROM t3_gene         UNION ALL SELECT * FROM t3_transcript
-      UNION ALL SELECT * FROM t4_gene         UNION ALL SELECT * FROM t4_transcript
-      UNION ALL SELECT * FROM t5_gene         UNION ALL SELECT * FROM t5_transcript
-      UNION ALL SELECT * FROM t6_gene         UNION ALL SELECT * FROM t6_transcript
-      UNION ALL SELECT * FROM t7_gene         UNION ALL SELECT * FROM t7_transcript
-      UNION ALL SELECT * FROM t8_gene         UNION ALL SELECT * FROM t8_transcript
-      UNION ALL SELECT * FROM t9_gene         UNION ALL SELECT * FROM t9_transcript
-      UNION ALL SELECT * FROM t10_gene        UNION ALL SELECT * FROM t10_transcript
-      UNION ALL SELECT * FROM t11_gene        UNION ALL SELECT * FROM t11_transcript
+      SELECT * FROM t1_pref_gene     UNION ALL SELECT * FROM t2_pref_gene
+      UNION ALL SELECT * FROM t3_pref_gene     UNION ALL SELECT * FROM t4_pref_gene
+      UNION ALL SELECT * FROM t5_pref_gene     UNION ALL SELECT * FROM t6_pref_gene
+      UNION ALL SELECT * FROM t7_pref_gene     UNION ALL SELECT * FROM t8_pref_gene
+      UNION ALL SELECT * FROM t9_pref_gene     UNION ALL SELECT * FROM t10_pref_gene
+      UNION ALL SELECT * FROM t11_pref_gene
+      UNION ALL SELECT * FROM t1_pref_transcript  UNION ALL SELECT * FROM t2_pref_transcript
+      UNION ALL SELECT * FROM t3_pref_transcript  UNION ALL SELECT * FROM t4_pref_transcript
+      UNION ALL SELECT * FROM t5_pref_transcript  UNION ALL SELECT * FROM t6_pref_transcript
+      UNION ALL SELECT * FROM t7_pref_transcript  UNION ALL SELECT * FROM t8_pref_transcript
+      UNION ALL SELECT * FROM t9_pref_transcript  UNION ALL SELECT * FROM t10_pref_transcript
+      UNION ALL SELECT * FROM t11_pref_transcript
+      UNION ALL SELECT * FROM t1_gene          UNION ALL SELECT * FROM t2_gene
+      UNION ALL SELECT * FROM t3_gene          UNION ALL SELECT * FROM t4_gene
+      UNION ALL SELECT * FROM t5_gene          UNION ALL SELECT * FROM t6_gene
+      UNION ALL SELECT * FROM t7_gene          UNION ALL SELECT * FROM t8_gene
+      UNION ALL SELECT * FROM t9_gene          UNION ALL SELECT * FROM t10_gene
+      UNION ALL SELECT * FROM t11_gene
+      UNION ALL SELECT * FROM t1_transcript    UNION ALL SELECT * FROM t2_transcript
+      UNION ALL SELECT * FROM t3_transcript    UNION ALL SELECT * FROM t4_transcript
+      UNION ALL SELECT * FROM t5_transcript    UNION ALL SELECT * FROM t6_transcript
+      UNION ALL SELECT * FROM t7_transcript    UNION ALL SELECT * FROM t8_transcript
+      UNION ALL SELECT * FROM t9_transcript    UNION ALL SELECT * FROM t10_transcript
+      UNION ALL SELECT * FROM t11_transcript
       UNION ALL SELECT * FROM arba_gene
     ),
 

--- a/Model/lib/psql/webready/orgSpecific/TranscriptProduct_p.psql
+++ b/Model/lib/psql/webready/orgSpecific/TranscriptProduct_p.psql
@@ -40,8 +40,30 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp as
         AND LOWER(TRIM(tp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
     ),
 
+    -- Informative gene feature products for GFP fallback (uninformative products excluded)
+    informative_gfp AS (
+      SELECT gfp.na_feature_id AS gene_na_feature_id, gfp.product, gfp.assigned_by, gfp.is_preferred
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN apidb.GeneFeatureProduct gfp ON gfp.na_feature_id = t.gene_na_feature_id
+      WHERE gfp.product IS NOT NULL
+        AND TRIM(gfp.product) != ''
+        AND gfp.product !~* '(hypothetical[_ ]protein|unspecified product|conserved hypothetical protein|predicted protein|protein of unknown function|uncharacterized protein|conserved protein,\s*unknown function|---na---|contig)'
+        AND NOT (gfp.product ~* '^has domain\(s\) with predicted' AND (gfp.product LIKE '%,%' OR gfp.product ~* ' and '))
+        AND NOT (gfp.product NOT LIKE '% %' AND gfp.product LIKE 'XM%')
+        AND gfp.product !~ '^CAD\d+(\.\d+)?$'
+        AND gfp.product !~* 'conserved\s+\w+\s+protein,?\s*unknown\s+function'
+        AND gfp.product !~* 'uncharacterized\s+loc\d+'
+        AND gfp.product NOT LIKE 'CSON%'
+        AND gfp.product NOT LIKE 'hypothetical protein BGH%'
+        AND gfp.product NOT LIKE 'DEHA2A%'
+        AND NOT (gfp.product NOT LIKE '% %' AND (gfp.product ~ '^[A-Z]{2,4}\d{4,}$' OR gfp.product ~ '^[A-Z]{3,5}_\d+$' OR gfp.product ~ '^LOC\d+$' OR gfp.product ~ '^[A-Z]+\d+\.[0-9]+$'))
+        AND gfp.product NOT LIKE 'Similar to [%'
+        AND gfp.product NOT LIKE '%UniProtKB%'
+        AND LOWER(TRIM(gfp.product)) NOT IN ('protein', 'gene product', 'gene', 'orf')
+    ),
+
     -- ===========================================================
-    -- Pass 1: Preferred transcript products, walking tier hierarchy
+    -- Pass 1: Preferred transcript products, all tiers (rules 1-11)
     -- ===========================================================
 
     -- Tier 1 (VEuPathDB) preferred
@@ -173,7 +195,7 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp as
     ),
 
     -- ===========================================================
-    -- Pass 2: Non-preferred transcript products, walking tier hierarchy
+    -- Pass 2: Non-preferred transcript products, all tiers (rules 12-22)
     -- ===========================================================
 
     -- Tier 1 (VEuPathDB) non-preferred
@@ -301,6 +323,239 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp as
       GROUP BY t.source_id
     ),
 
+    -- ===========================================================
+    -- Pass 3: Preferred GFP fallback, all tiers (rules 23-33)
+    -- Each transcript inherits all GFP annotations for its gene
+    -- ===========================================================
+
+    t1_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             23 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'veupathdb_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'veupathdb' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t2_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             24 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'apollo' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t3_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             25 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'community' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t4_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             26 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
+                                         'franzen','fritzlab','hertzfowlerlab','jcarltonlab','kissingerlab',
+                                         'liverpool','lukeslab','mcbridelab','msu','painlab','requenalab',
+                                         'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
+                                         'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
+        AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t5_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             27 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
+        AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t6_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             28 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'ensembl' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t7_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             29 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
+        AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t8_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             30 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'refseq' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t9_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             31 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'entrezgene' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t10_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             32 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('genbank','gb') AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+    t11_pref_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             33 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_preferred_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'pfam' AND igfp.is_preferred = 1
+      GROUP BY t.source_id
+    ),
+
+    -- ===========================================================
+    -- Pass 4: Non-preferred GFP fallback, all tiers (rules 34-44)
+    -- ===========================================================
+
+    t1_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             34 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'veupathdb_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'veupathdb'
+      GROUP BY t.source_id
+    ),
+    t2_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             35 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'apollo_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'apollo'
+      GROUP BY t.source_id
+    ),
+    t3_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             36 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'community_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'community'
+      GROUP BY t.source_id
+    ),
+    t4_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             37 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'lab_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('anderssonlab','berna','beverleylab','corridalab','flegontovlab',
+                                         'franzen','fritzlab','hertzfowlerlab','jcarltonlab','kissingerlab',
+                                         'liverpool','lukeslab','mcbridelab','msu','painlab','requenalab',
+                                         'siegelab','stukenbrocklab','tachezylab','tarletonlab','ubc',
+                                         'ulaval','valkiunaslab','wittwerlab','yurchenkolab')
+      GROUP BY t.source_id
+    ),
+    t5_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             38 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genomedb_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('jcvi','jgi','sanger','pombase','dictybase','aspgd','cgd','sgd','genedb')
+      GROUP BY t.source_id
+    ),
+    t6_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             39 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'ensembl_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'ensembl'
+      GROUP BY t.source_id
+    ),
+    t7_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             40 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'uniprot_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('uniprot','uniprotkb/trembl','uniprot/pfam')
+      GROUP BY t.source_id
+    ),
+    t8_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             41 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'refseq_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'refseq'
+      GROUP BY t.source_id
+    ),
+    t9_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             42 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'entrezgene_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'entrezgene'
+      GROUP BY t.source_id
+    ),
+    t10_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             43 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'genbank_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) IN ('genbank','gb')
+      GROUP BY t.source_id
+    ),
+    t11_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             44 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'pfam_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'pfam'
+      GROUP BY t.source_id
+    ),
+
+    -- ===========================================================
+    -- Rule 45: ARBA (only when all tier sources are uninformative)
+    -- ===========================================================
+    arba_gene AS (
+      SELECT t.source_id,
+             SUBSTR(STRING_AGG(DISTINCT igfp.product, ', ' ORDER BY igfp.product), 1, 4000) AS product,
+             45 AS source_rule, COUNT(DISTINCT igfp.product) AS value_count, 'arba_gene' AS rule_description
+      FROM :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp t
+      INNER JOIN informative_gfp igfp ON igfp.gene_na_feature_id = t.gene_na_feature_id
+      WHERE LOWER(igfp.assigned_by) = 'arba'
+      GROUP BY t.source_id
+    ),
+
     all_products AS (
       SELECT * FROM t1_pref_transcript
       UNION ALL SELECT * FROM t2_pref_transcript
@@ -324,6 +579,29 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp as
       UNION ALL SELECT * FROM t9_transcript
       UNION ALL SELECT * FROM t10_transcript
       UNION ALL SELECT * FROM t11_transcript
+      UNION ALL SELECT * FROM t1_pref_gene
+      UNION ALL SELECT * FROM t2_pref_gene
+      UNION ALL SELECT * FROM t3_pref_gene
+      UNION ALL SELECT * FROM t4_pref_gene
+      UNION ALL SELECT * FROM t5_pref_gene
+      UNION ALL SELECT * FROM t6_pref_gene
+      UNION ALL SELECT * FROM t7_pref_gene
+      UNION ALL SELECT * FROM t8_pref_gene
+      UNION ALL SELECT * FROM t9_pref_gene
+      UNION ALL SELECT * FROM t10_pref_gene
+      UNION ALL SELECT * FROM t11_pref_gene
+      UNION ALL SELECT * FROM t1_gene
+      UNION ALL SELECT * FROM t2_gene
+      UNION ALL SELECT * FROM t3_gene
+      UNION ALL SELECT * FROM t4_gene
+      UNION ALL SELECT * FROM t5_gene
+      UNION ALL SELECT * FROM t6_gene
+      UNION ALL SELECT * FROM t7_gene
+      UNION ALL SELECT * FROM t8_gene
+      UNION ALL SELECT * FROM t9_gene
+      UNION ALL SELECT * FROM t10_gene
+      UNION ALL SELECT * FROM t11_gene
+      UNION ALL SELECT * FROM arba_gene
     ),
 
     ranked_products AS (
@@ -334,7 +612,7 @@ create unlogged table :SCHEMA.:CLEAN_ORG_ABBREVTranscriptProductTmp as
   SELECT t.source_id,
          COALESCE(rp.product, 'unspecified product') as product,
          COALESCE(rp.value_count, 0) as value_count,
-         COALESCE(rp.source_rule, 23) as source_rule,
+         COALESCE(rp.source_rule, 46) as source_rule,
          COALESCE(rp.rule_description, 'unspecified') as source_rule_description,
          ':PROJECT_ID' as project_id,
          ':ORG_ABBREV' as org_abbrev,


### PR DESCRIPTION
…TempTranscriptProduct hierarchy

GeneProduct_p: reorder rule numbering to match TempGeneProduct — all preferred GFP first (1-11), then preferred TP (12-22, with 1-distinct-transcript HAVING constraint), then non-preferred GFP (23-33), non-preferred TP (34-44, with constraint), ARBA (45), fallback 46. Fix uninformative filter from '%Source:UniProt%' to '%UniProtKB%'. Add transcript_na_feature_id tracking to informative_tp to support the HAVING constraint.

TranscriptProduct_p: add informative_gfp CTE and GFP fallback CTEs (rules 23-44, preferred then non-preferred GFP via gene_na_feature_id), add ARBA rule 45, fix COALESCE fallback from 23 to 46.