### PR TITLE
Bug: enrichmentAnalysis returning nonsense p-values (>1)

### DIFF
--- a/Model/bin/enrichmentAnalysis
+++ b/Model/bin/enrichmentAnalysis
@@ -127,6 +127,8 @@ def main(argv = None):
 
         # print results.shape
 
+        inputCols = list(range(data.shape[1]))
+        results = results[['foldEnrichment', 'oddsRatio', 'percent', 'pValue', 'benjamini', 'bonferroni'] + inputCols]
         results.to_csv(sys.stdout, sep="\t", header = False, index = False)
 
     except:


### PR DESCRIPTION
### What was happening

The enrichment analysis tool was returning p-values greater than 1 in the frontend — which is statistically impossible (p-values must always be between 0 and 1).

### Root cause: two issues compounding each other

**1. The script was silently broken since a pandas upgrade**

An older pandas method (`DataFrame.sort()`) had been removed in the current pandas version. The script was crashing internally, but the error was caught silently, so the frontend received empty results rather than an obvious error. "No enrichment results" can look like a legitimate response, so nobody noticed.

**2. Column ordering changed when the crash was fixed (October 2025)**

Once the crash was fixed (switching to `sort_values()`), the script started producing output again — but with columns in the wrong order.

In older Python, dictionary keys had no guaranteed order, so pandas would sort them **alphabetically** when building the results table. The frontend was written to expect that alphabetical order:

```
foldEnrichment | oddsRatio | percent | pValue | benjamini | bonferroni | ...
```
(The adjusted stats are merged alphabetically from another DataFrame.)

In modern Python (3.7+), dictionaries preserve **insertion order** instead. The code inserts `pValue` first, so that's what came out first:

```
pValue | percent | oddsRatio | foldEnrichment | ...
```

The frontend, reading columns by position, was picking up `foldEnrichment` values where it expected `pValue`. Fold enrichment scores are commonly greater than 1 — hence the nonsense p-values.

### Fix

Explicitly reorder the output columns before writing to stdout, so the output is always in the correct order regardless of Python or pandas version:

```python
inputCols = list(range(data.shape[1]))
results = results[['foldEnrichment', 'oddsRatio', 'percent', 'pValue', 'benjamini', 'bonferroni'] + inputCols]
results.to_csv(sys.stdout, sep="\t", header=False, index=False)
```
