### PR TITLE
Add N/C-terminal (tag-location) selector to Cellular Localization GO image searches

### DIFF
--- a/Model/lib/dst/cellularLocalization.dst
+++ b/Model/lib/dst/cellularLocalization.dst
@@ -6,6 +6,7 @@ prop=datasetDisplayName
 prop=datasetShortDisplayName
 prop=buildNumberIntroduced
 prop=includeProjects
+prop=organismAbbrev
 >templateTextStart<
 
     <question name="GenesByGoTermCL_${datasetName}"
@@ -17,6 +18,8 @@ prop=includeProjects
          newBuild="${buildNumberIntroduced}">
 
         <paramRef ref="geneParams.cellularLocImageDataset" default="${datasetName}" visible="false"/>
+        <paramRef ref="organismParams.organismAbbrev" default="${organismAbbrev}" visible="false"/>
+        <paramRef ref="geneParams.cellularLocImageType"/>
         <paramRef ref="geneParams.go_typeahead_cl"/>
         <paramRef ref="geneParams.go_term"/>
 

--- a/Model/lib/wdk/model/questions/params/geneParams.xml
+++ b/Model/lib/wdk/model/questions/params/geneParams.xml
@@ -58,6 +58,17 @@
       <help>Cellular Localization Image Dataset</help>
     </flatVocabParam>
 
+    <flatVocabParam name="cellularLocImageType"
+                    queryRef="GeneVQ.CellularLocImageType"
+                    prompt="Tag location / image type"
+                    quote="true"
+                    visible="true"
+                    multiPick="false"
+                    displayType="checkBox"
+                    dependedParamRef="geneParams.cellularLocImageDataset" >
+      <suggest default="Any"/>
+      <help><![CDATA[Choose which cellular-localization images to view. For TrypTag, select the N- or C-terminal endogenous tag; other datasets list their available image types. "Any" shows all.]]></help>
+    </flatVocabParam>
     <!--
     <flatVocabParam name="phenotypeDataset"
                     queryRef="GeneVQ.PhenotypeDataset"
@@ -6986,6 +6997,40 @@ products of your selected type (or types).<br><br>
               , apidb.nafeatureimage fi
           WHERE d.external_database_id = r.external_database_id
             AND r.external_database_release_id = fi.external_database_release_id
+        ]]>
+      </sql>
+    </sqlQuery>
+
+
+    <!-- Distinct image types available for one gene-image dataset, as LIKE patterns.
+         Generic: term = internal = the raw image_type. Special-cased for TrypTag,
+         whose 6 raw image_types collapse to two termini: term "N-terminal"/"C-terminal"
+         shown to the user, internal "N terminal%"/"C terminal%" used by the LIKE filter.
+         The leading 'Any' -> '%' row is the default (no filtering). -->
+    <sqlQuery name="CellularLocImageType" isCacheable="false" doNotTest="1">
+      <paramRef ref="geneParams.cellularLocImageDataset"/>
+      <column name="term"/>
+      <column name="internal"/>
+      <sql>
+        <![CDATA[
+          SELECT 'Any' AS term, '%' AS internal
+          UNION
+          SELECT DISTINCT
+              CASE WHEN d.name LIKE '%TrypTag%'
+                   THEN regexp_replace(fi.image_type, '^([NC]) terminal tag.*$', '\1-terminal')
+                   ELSE fi.image_type
+              END AS term
+            , CASE WHEN d.name LIKE '%TrypTag%'
+                   THEN regexp_replace(fi.image_type, '^([NC]) terminal tag.*$', '\1 terminal%')
+                   ELSE fi.image_type
+              END AS internal
+          FROM sres.externaldatabase d
+              , sres.externaldatabaserelease r
+              , apidb.nafeatureimage fi
+          WHERE d.external_database_id = r.external_database_id
+            AND r.external_database_release_id = fi.external_database_release_id
+            AND d.name = $$cellularLocImageDataset$$
+          ORDER BY term
         ]]>
       </sql>
     </sqlQuery>

--- a/Model/lib/wdk/model/questions/params/organismParams.xml
+++ b/Model/lib/wdk/model/questions/params/organismParams.xml
@@ -26,6 +26,13 @@
     <stringParam name="organismSite" visible="false" number="false">
     </stringParam>
 
+    <!-- Hidden, generic org-abbrev holder. Used to prune org_abbrev-partitioned
+         webready tables. Set per-question via a paramRef default (e.g. a dataset
+         template's ${organismAbbrev}). -->
+    <stringParam name="organismAbbrev" visible="false" number="false">
+      <help>Organism abbreviation (webready partition key).</help>
+    </stringParam>
+
     <!-- UNUSED, keep as an example
 
      <stringParam name="hiddenOrganismGiardia" visible="false">

--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -1845,12 +1845,16 @@
       </postCacheUpdateSql>
 
       <testParamValues>
+        <paramValue name="organismAbbrev">tbruTREU927</paramValue>
         <paramValue name="cellularLocImageDataset">TrypTag</paramValue>
+        <paramValue name="cellularLocImageType">Any</paramValue>
         <paramValue name="go_typeahead_cl">N/A</paramValue>
         <paramValue name="go_term">binding</paramValue>
       </testParamValues>
 
+      <paramRef ref="organismParams.organismAbbrev"/>
       <paramRef ref="geneParams.cellularLocImageDataset"/>
+      <paramRef ref="geneParams.cellularLocImageType"/>
       <paramRef ref="geneParams.go_typeahead_cl"/>
       <paramRef ref="geneParams.go_term"/>
       <column name="project_id"/>
@@ -1862,6 +1866,15 @@
       <column name="image"/>
       <sql>
         <![CDATA[
+          -- webready.transcriptattributes_p and gotermsummary_p are partitioned by
+          -- org_abbrev; filtering on $$organismAbbrev$$ (set per-dataset from
+          -- the template's ${organismAbbrev}) prunes to a single organism partition, which
+          -- is what keeps this fast (the apidbtuning views have no na_feature_id-leading
+          -- index and were catastrophically slow here).
+          -- Images (apidb.nafeatureimage) for these datasets always attach to the GENE
+          -- feature (verified: 100% GeneFeature for both TrypTag and the Giardia DawsonLab
+          -- set), so a single equality join on gene_na_feature_id suffices -- no
+          -- gene-vs-transcript OR needed.
           SELECT gs.transcript_source_id AS source_id
             , gs.gene_source_id
             , ta.project_id
@@ -1869,16 +1882,20 @@
             , string_agg(DISTINCT gs.evidence_code, ', ') AS evidence_code
             , string_agg(regexp_replace(fi.note, ' <a href.+$', NULL), '; ') AS note
             , max(fi.image_uri) AS image
-          FROM apidbtuning.TranscriptAttributes ta
-            , apidbtuning.GoTermSummary gs
+          FROM webready.transcriptattributes_p ta
+            , webready.gotermsummary_p gs
             , apidb.nafeatureimage fi
             , sres.externaldatabaserelease r
             , sres.externaldatabase d
-          WHERE ta.aa_sequence_id = gs.aa_sequence_id
+          WHERE ta.org_abbrev = $$organismAbbrev$$
+            AND gs.org_abbrev = $$organismAbbrev$$
+            AND ta.aa_sequence_id = gs.aa_sequence_id
             -- Join to external database to filter by dataset
             AND fi.external_database_release_id = r.external_database_release_id
             AND r.external_database_id = d.external_database_id
             AND d.name = $$cellularLocImageDataset$$
+            -- Filter by image type / tag location (LIKE pattern from vocab; 'Any' -> '%')
+            AND fi.image_type LIKE $$cellularLocImageType$$
             -- Filter by GO term
             AND (
               gs.go_id IN ($$go_typeahead_cl$$)
@@ -1888,7 +1905,8 @@
                 OR CONCAT(gs.go_id, ' : ', gs.go_term_name) LIKE REPLACE($$go_term$$, '*', '%')
               )
             )
-            AND (fi.na_feature_id = ta.gene_na_feature_id OR fi.na_feature_id = ta.na_feature_id)
+            -- Images attach to the gene feature (see note above)
+            AND fi.na_feature_id = ta.gene_na_feature_id
           GROUP BY gs.transcript_source_id, gs.gene_source_id, ta.project_id
         ]]>
       </sql>

--- a/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/GeneImage.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/GeneImage.java
@@ -8,6 +8,8 @@ public class GeneImage extends DatasetInjector {
   public void injectTemplates() {
       String projectName = getPropValue("projectName");
       setPropValue("includeProjects", projectName + ",UniDB");
+      // expose org abbrev so the question template can prune the webready partition
+      setPropValue("organismAbbrev", getOrganismAbbrevFromDatasetName());
 
       injectTemplate("geneImageGoTermQuestion");
       injectTemplate("geneImageGoTermOntology");


### PR DESCRIPTION
## Summary
Restores the missing **terminus / image-type parameter** on the dataset-generated `GenesByGoTermCL_*` searches (TrypTag on TriTrypDB, DawsonLab on GiardiaDB). Users can again pick which cellular-localization images to view — for TrypTag, **N-terminal vs C-terminal** endogenous tag.

## What changed
- **`cellularLocImageType`** — new dataset-dependent `flatVocabParam` (radio: `checkBox` + `multiPick=false`; default **`Any`** = no filter). Its vocab (`GeneVQ.CellularLocImageType`) returns the distinct `apidb.nafeatureimage.image_type` values for the dependent dataset; TrypTag's six raw types collapse to **`N-terminal`/`C-terminal`** for display, with `LIKE` patterns (`N terminal%` / `C terminal%`) as the internal filter values. Generic — any gene-image dataset gets its own image types.
- **`GenesByGoTermCLDataset`** — filters images by `fi.image_type LIKE $$cellularLocImageType$$`.
- **Performance** — the shared query was rebuilt onto the `org_abbrev`-partitioned **webready** tables (`transcriptattributes_p` / `gotermsummary_p`), pruned by a new hidden generic param **`organismParams.organismAbbrev`**. The gene/transcript `OR` join was dropped (verified these datasets' images are 100% gene-feature). **~120s timeout → ~1s.**
- **`GeneImage`** injector now exposes `${organismAbbrev}`; **`cellularLocalization.dst`** passes it (hidden) plus the new selector into the generated question.

## Verification
- `wb model` build green on a dev instance (`bld` + `presenterInjectTemplates` + `wdkXml` + reload, exit 0) — model assembles, dependency `cellularLocImageType → cellularLocImageDataset` resolves, default `Any`.
- Assembled SQL run read-only in psql: terminus selection flips the returned image (`_N_phase.jpg` ↔ `_C_phase.jpg`); vocab returns `Any`/`N-terminal`/`C-terminal`; warm exec ~1.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)