### PR TITLE
Add TriTrypDB, FungiDB, AmoebaDB to EDA phenotype includeProjects

### DIFF
--- a/Model/lib/wdk/model/records/geneRecord.xml
+++ b/Model/lib/wdk/model/records/geneRecord.xml
@@ -794,7 +794,7 @@
          <table name="EdaPhenotypeGraphsDataTable"
                 inReportMaker="false"
                  displayName="Phenotype Graphs Data Table"
-                 includeProjects="ToxoDB,UniDB,PlasmoDB"
+                 includeProjects="PlasmoDB,ToxoDB,TriTrypDB,FungiDB,AmoebaDB,UniDB"
                  queryRef="GeneTables.EdaPhenotypeGraphsDataTable" >
             <columnAttribute name="dataset_id" displayName="Dataset" internal="true" />
             <columnAttribute name="variable" displayName="Variable"/>
@@ -1310,7 +1310,7 @@ name" internal="true"/>
         <table name="EdaPhenotypeDatasets"
                  displayName="Phenotype Datasets"
                  inReportMaker="false"
-                 includeProjects="ToxoDB,UniDB,PlasmoDB"
+                 includeProjects="PlasmoDB,ToxoDB,TriTrypDB,FungiDB,AmoebaDB,UniDB"
                  queryRef="GeneTables.EdaPhenotypeDatasets" >
 
             <columnAttribute internal="true" displayName="source_id" name="source_id"/>

--- a/Model/lib/wdk/model/records/geneTableQueries.xml
+++ b/Model/lib/wdk/model/records/geneTableQueries.xml
@@ -984,7 +984,7 @@
     </sqlQuery>
 
 
-       <sqlQuery name="EdaPhenotypeDatasets" includeProjects="ToxoDB,UniDB,PlasmoDB">
+       <sqlQuery name="EdaPhenotypeDatasets" includeProjects="PlasmoDB,ToxoDB,TriTrypDB,FungiDB,AmoebaDB,UniDB">
             <column name="source_id" />
             <column name="project_id" />
             <column name="project_id_url" />
@@ -4574,7 +4574,7 @@ from (
 
 
 
-          <sqlQuery name="EdaPhenotypeGraphsDataTable" isCacheable="false" includeProjects="ToxoDB,UniDB,PlasmoDB">
+          <sqlQuery name="EdaPhenotypeGraphsDataTable" isCacheable="false" includeProjects="PlasmoDB,ToxoDB,TriTrypDB,FungiDB,AmoebaDB,UniDB">
             <column name="source_id"/>
             <column name="project_id"/>
             <column name="dataset_id"/>


### PR DESCRIPTION
## Problem

Phenotype sections were reported missing from FungiDB gene pages. The cause is not data and not the query — these model nodes were scoped to `ToxoDB,UniDB,PlasmoDB`:

| File | Node |
|---|---|
| `geneTableQueries.xml:987` | `EdaPhenotypeDatasets` sqlQuery |
| `geneTableQueries.xml:4577` | `EdaPhenotypeGraphsDataTable` sqlQuery |
| `geneRecord.xml:797` | `EdaPhenotypeGraphsDataTable` table |
| `geneRecord.xml:1313` | `EdaPhenotypeDatasets` table |

WDK therefore drops both queries and tables during "Excluding model resources..." on every other site, so the sections can never render regardless of loaded data.

EDA phenotype data exists for **PlasmoDB, ToxoDB, TriTrypDB, FungiDB, AmoebaDB, UniDB** — three of which were missing from the list.

## Change

All four nodes set to `PlasmoDB,ToxoDB,TriTrypDB,FungiDB,AmoebaDB,UniDB`. This also fixes TriTrypDB and AmoebaDB, which had the identical omission.

## Verification (FungiDB dev instance)

Before:
```
WdkModelException: Query Set GeneTables does not include query EdaPhenotypeGraphsDataTable
```

After `wb model`, both queries resolve and `presenterInjectTemplates` expands real FungiDB datasets against populated `eda.attributevalue_*` tables: `CGD_pheno`, `calbSC5314_Shapiro_2021`, `ncraOR74A_knockout_mutants`, `VEuPathDB_curated_phenotype`, `PHI-base_curated_phenotype`, `mory70-15_Magnaporthe_Pheno`. Both tables confirmed present in the built `individuals.txt` under the `phenotype` category.

Not yet verified: live page rendering, which additionally depends on the dataset↔table association rows written at dataset-injection time.

## Deliberately out of scope

- **`UserDatasetsEdaPhenotype`** (`geneRecord.xml:1207`) left at `ToxoDB,UniDB,PlasmoDB` — user-uploaded phenotype data, a separate product decision. Its sqlQuery has no `includeProjects` at all; only the table is gated.
- **`EdaCellularLocalization*`** keeps its own curated list (`ToxoDB,TriTrypDB,UniDB`). These lists drift independently per data availability — worth a separate look if FungiDB has cellular-localization EDA data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)