### PR TITLE
Community counts attribute query

### DIFF
--- a/Model/lib/wdk/model/records/organismAttributeQueries.xml
+++ b/Model/lib/wdk/model/records/organismAttributeQueries.xml
@@ -101,7 +101,6 @@
       <column name="tfbscount"/>
       <column name="gocount"/>
       <column name="proteomicscount"/>
-      <column name="communitycount"/>
       <column name="organism_name"/>
       <column name="organism_full"/>
       <column name="isOrganellar_flag"/>
@@ -113,7 +112,6 @@
       <column name="go_flag"/>
       <column name="ec_flag"/>
       <column name="rtpcr_flag"/>
-      <column name="community_flag"/>
       <column name="tfbs_flag"/>
       <column name="hasHTSIsolate_flag"/>
 <!--       <column name="hasPopset_flag"/> -->
@@ -158,7 +156,6 @@
                  nullif(oa.gocount,0) as gocount,
                  nullif(oa.tfbscount,0) as tfbscount,
                  nullif(oa.proteomicscount,0) as proteomicscount,
-                 nullif(oa.communitycount,0) as communitycount, 
                  CASE oa.isOrganellar WHEN 0 THEN 'no' ELSE 'yes' END as isOrganellar_flag,
                  CASE oa.arraygenecount WHEN 0 THEN 'none' ELSE 'yes' END as array_flag,
                  CASE oa.chipchipgenecount WHEN 0 THEN 'none' ELSE 'yes' END as chipchip_flag,
@@ -168,7 +165,6 @@
                  CASE oa.ecnumbercount WHEN 0 THEN 'none' ELSE 'yes' END as ec_flag,
                  CASE oa.gocount WHEN 0 THEN 'none' ELSE 'yes' END as go_flag,
                  CASE oa.rtpcrcount WHEN 0 THEN 'none' ELSE 'yes' END as rtpcr_flag,
-                 CASE oa.communitycount WHEN 0 THEN 'none' ELSE 'yes' END as community_flag,
                  CASE oa.tfbscount WHEN 0 THEN 'none' ELSE 'yes' END as tfbs_flag,
                  CASE oa.hasHTSIsolate WHEN 0 THEN 'none' ELSE 'yes' END as hasHTSIsolate_flag,
                  --CASE oa.hasPopset WHEN 0 THEN 'none' ELSE 'yes' END as hasPopset_flag,
@@ -240,6 +236,35 @@
         ]]>
       </sql>
     </sqlQuery>
+
+
+        <sqlQuery name="CommunityCounts">
+            <column name="source_id"/>
+            <column name="project_id"/>
+            <column name="communitycount"/>
+            <column name="community_flag"/>
+            <sql>
+            <![CDATA[
+              SELECT o.source_id, o.project_id,
+                     nullif(count(comm.stable_id), 0) as communitycount,
+                     CASE WHEN count(comm.stable_id) = 0 THEN 'none' ELSE 'yes' END as community_flag
+              FROM apidbtuning.organismAttributes o
+                   LEFT JOIN apidbtuning.GeneAttributes ga
+                          ON  ga.taxon_id   = o.component_taxon_id
+                          AND ga.project_id = o.project_id
+                   LEFT JOIN (
+                          SELECT distinct stable_id, project_name
+                          FROM   @REMOTE_COMMENT_SCHEMA@MappedComment
+                          WHERE  is_visible = true
+                            AND  comment_target_id = 'gene'
+                   ) comm ON  comm.stable_id    = ga.source_id
+                          AND comm.project_name = ga.project_id
+              where o.project_id = '@PROJECT_ID@' or '@PROJECT_ID@' = 'UniDB'
+              GROUP BY o.source_id, o.project_id
+                ]]>
+           </sql>
+        </sqlQuery>
+
 
         <sqlQuery name="BuscoGenomeCounts">
             <column name="source_id"/>

--- a/Model/lib/wdk/model/records/organismRecords.xml
+++ b/Model/lib/wdk/model/records/organismRecords.xml
@@ -180,8 +180,6 @@
           help="Number of genes that have evidence of protein expression based on Mass Spectrometry studies" align="right"/>
         <columnAttribute name="tfbscount" type="number" displayName="TFBS" attributeCategory="genemetrics"  
           help="Total number of genes having evidence of expression based on transcription factor binding site identification experiments" align="right" />
-        <columnAttribute name="communitycount" type="number"  displayName="User comments" attributeCategory="genemetrics"  
-          help="Number of genes with comments/notes from the research community" align="right"/>
 
         <columnAttribute name="organism_name" displayName="Organism (text)" inReportMaker="false"/>
         <columnAttribute name="organism_full" displayName="Organism" inReportMaker="false"/>
@@ -298,15 +296,6 @@
            <text>
              <![CDATA[
              <img width="8" border="0" alt="$$rtpcr_flag$$" src="/a/images/reddot.gif" style="display:$$rtpcr_flag$$"/>
-             ]]>
-           </text>
-          </textAttribute>
-
-         <columnAttribute name="community_flag" inReportMaker="false"/>
-         <textAttribute name="hasCommunity" displayName="Community" align="center" inReportMaker="false" >
-           <text>
-             <![CDATA[
-             <img width="8" border="0" alt="$$community_flag$$" src="/a/images/reddot.gif" style="display:$$community_flag$$"/>
              ]]>
            </text>
           </textAttribute>
@@ -434,6 +423,18 @@
                        help ="VectorBase genomes initial annotation source (version 1.0) is either from NCBI RefSeq or from the genome authors own pipeline. Subsequent annotations are provided by VectorBase, either by the community (currently via Apollo) or by the EBI pipeline (via predictions and alignments to external databases)." />
      </attributeQueryRef>
 
+     <attributeQueryRef ref="OrganismAttributes.CommunityCounts">
+       <columnAttribute name="communitycount" type="number" displayName="User comments" attributeCategory="genemetrics"
+          help="Number of genes with comments/notes from the research community" align="right"/>
+       <columnAttribute name="community_flag" inReportMaker="false"/>
+       <textAttribute name="hasCommunity" displayName="Community" align="center" inReportMaker="false" >
+         <text>
+           <![CDATA[
+           <img width="8" border="0" alt="$$community_flag$$" src="/a/images/reddot.gif" style="display:$$community_flag$$"/>
+           ]]>
+         </text>
+       </textAttribute>
+     </attributeQueryRef>
 
      <attributeQueryRef ref="OrganismAttributes.BuscoProteinCounts" excludeProjects="HostDB,EuPathDB">
        <columnAttribute name="busco_protein"  displayName="BUSCO Protein"

--- a/Model/lib/xml/tuningManager/apiTuningManager.xml
+++ b/Model/lib/xml/tuningManager/apiTuningManager.xml
@@ -1318,7 +1318,7 @@
     <intermediateTable name="DataSourceCount"/>
     <intermediateTable name="OrganismCentromere"/>
     <intermediateTable name="SequenceCount"/>
-    <intermediateTable name="CommunityCount"/>
+    <!-- intermediateTable name="CommunityCount"/ -->
     <intermediateTable name="ProfileCount"/>
     <!-- <intermediateTable name="PopsetCount"/> -->
     <intermediateTable name="GeneCount"/>
@@ -1396,7 +1396,7 @@
       ]]>
     </sql>
 
-    <sql>
+<!--    <sql>
       <![CDATA[
         CREATE UNLOGGED TABLE CommunityCount AS
         SELECT taxon_id, count(*) as communityCount
@@ -1410,7 +1410,7 @@
         GROUP BY taxon_id
       ]]>
     </sql>
-
+-->
     <sql>
       <![CDATA[
         CREATE UNLOGGED TABLE ProfileCount AS
@@ -1659,7 +1659,7 @@
                    coalesce(sc.contig_num, 0) as contigCount,
                    coalesce(sc.supercont_num, 0) as supercontigCount,
                    coalesce(sc.chrom_num, 0) as chromosomeCount,
-                   coalesce(cc.communityCount, 0) as communityCount,
+                  -- coalesce(cc.communityCount, 0) as communityCount,
                    --coalesce(psc.popsetCount, 0) as popsetCount,
                    coalesce(pc.geneArrayCount, 0) as arrayGeneCount,
                    coalesce(pc.rnaSeqCount, 0) as rnaSeqCount,
@@ -1671,7 +1671,7 @@
               LEFT JOIN DataSourceCount dsc ON o.taxon_id = dsc.taxon_id
               LEFT JOIN OrganismCentromere oc ON o.taxon_id = oc.taxon_id
               LEFT JOIN SequenceCount sc ON o.taxon_id = sc.taxon_id
-              LEFT JOIN CommunityCount cc ON o.taxon_id = cc.taxon_id
+              -- LEFT JOIN CommunityCount cc ON o.taxon_id = cc.taxon_id
               LEFT JOIN GeneCount gc ON o.taxon_id = gc.taxon_id
               --LEFT JOIN popsetCount psc ON o.taxon_id = psc.taxon_id
               LEFT JOIN profileCount pc ON o.taxon_id = pc.taxon_id

--- a/Model/lib/xml/tuningManager/apiTuningManager.xml
+++ b/Model/lib/xml/tuningManager/apiTuningManager.xml
@@ -1318,7 +1318,6 @@
     <intermediateTable name="DataSourceCount"/>
     <intermediateTable name="OrganismCentromere"/>
     <intermediateTable name="SequenceCount"/>
-    <!-- intermediateTable name="CommunityCount"/ -->
     <intermediateTable name="ProfileCount"/>
     <!-- <intermediateTable name="PopsetCount"/> -->
     <intermediateTable name="GeneCount"/>
@@ -1396,21 +1395,6 @@
       ]]>
     </sql>
 
-<!--    <sql>
-      <![CDATA[
-        CREATE UNLOGGED TABLE CommunityCount AS
-        SELECT taxon_id, count(*) as communityCount
-        FROM Geneattributes
-        WHERE (source_id, project_id) IN (
-              SELECT distinct stable_id, project_name
-              FROM usercomments_userdb_betan.mappedComment
-              WHERE is_visible = '1'
-                AND comment_target_id = 'gene'
-          )
-        GROUP BY taxon_id
-      ]]>
-    </sql>
--->
     <sql>
       <![CDATA[
         CREATE UNLOGGED TABLE ProfileCount AS
@@ -1659,7 +1643,6 @@
                    coalesce(sc.contig_num, 0) as contigCount,
                    coalesce(sc.supercont_num, 0) as supercontigCount,
                    coalesce(sc.chrom_num, 0) as chromosomeCount,
-                  -- coalesce(cc.communityCount, 0) as communityCount,
                    --coalesce(psc.popsetCount, 0) as popsetCount,
                    coalesce(pc.geneArrayCount, 0) as arrayGeneCount,
                    coalesce(pc.rnaSeqCount, 0) as rnaSeqCount,
@@ -1671,7 +1654,6 @@
               LEFT JOIN DataSourceCount dsc ON o.taxon_id = dsc.taxon_id
               LEFT JOIN OrganismCentromere oc ON o.taxon_id = oc.taxon_id
               LEFT JOIN SequenceCount sc ON o.taxon_id = sc.taxon_id
-              -- LEFT JOIN CommunityCount cc ON o.taxon_id = cc.taxon_id
               LEFT JOIN GeneCount gc ON o.taxon_id = gc.taxon_id
               --LEFT JOIN popsetCount psc ON o.taxon_id = psc.taxon_id
               LEFT JOIN profileCount pc ON o.taxon_id = pc.taxon_id


### PR DESCRIPTION
Moves `communitycount` and `community_flag` off `OrganismAttributes.organismAttrs` into a new `OrganismAttributes.CommunityCounts` query that
  counts visible gene comments directly, rather than reading `apidbtuning.organismAttributes.communitycount`.

  Also removes an orphaned `<column name="community_flag"/>` from `organismAttrs` whose SELECT expression was already gone, and a duplicate `communitycount` columnAttribute.


  **Not yet validated:** `wb model` aborts earlier at `presenterInjectTemplates` on an unrelated `ClonedInsertEnds`/`sourceIdField` error, so `wdkXml` never ran. XML is well-formed per `xmllint`; WDK ref resolution and the SQL are unverified.

Last commit removes the dead `CommunityCount` tuning code from `apiTuningManager.xml`.

Also note that once approved this branch has to be merged to **dnaseq-merge-experiments** branch (not master).