### PR TITLE
Subset AntibodyArray gene graphs; give the data table its samples

### DIFF
--- a/Model/lib/dst/antibodyArray.dst
+++ b/Model/lib/dst/antibodyArray.dst
@@ -248,21 +248,24 @@ prop=datasetName
 prop=edaStudyStableId
 prop=edaEntityAbbrev
 >templateTextStart<
-UNION
-SELECT genes.string_value AS gene,
-       ag.display_name AS variable,
-       av.string_value,
-       av.number_value,
-       av.date_value,
+-- UNION ALL, not UNION: a measurement is identified by its sample, and two
+-- samples may legitimately record the same intensity for the same gene. Under
+-- UNION those rows collapse into one and the table silently loses data.
+UNION ALL
+SELECT genes.gene AS gene,
+       anc.sample_stable_id AS sample,
+       av.number_value AS value,
        '${datasetName}' AS dataset_id
 FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av,
-     eda.attributegraph_${edaStudyStableId}_${edaEntityAbbrev} ag,
-     (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) as string_value
+     -- The measurement entity is a child of the sample entity: the value lives
+     -- here, but the identity of what was measured lives one level up.
+     eda.ancestors_${edaStudyStableId}_${edaEntityAbbrev} anc,
+     (SELECT av.${edaEntityAbbrev}_stable_id, MIN(gi.gene) AS gene
       FROM eda.attributevalue_${edaStudyStableId}_${edaEntityAbbrev} av
       JOIN apidbtuning.GeneId gi ON gi.id = av.string_value
       WHERE av.attribute_stable_id = 'VEUPATHDB_GENE_ID'
       GROUP BY av.${edaEntityAbbrev}_stable_id) genes
-WHERE av.attribute_stable_id = ag.stable_id
+WHERE av.attribute_stable_id = 'NORMALIZED_INTENSITY'
   AND av.${edaEntityAbbrev}_stable_id = genes.${edaEntityAbbrev}_stable_id
-  AND av.attribute_stable_id != 'VEUPATHDB_GENE_ID'
+  AND anc.${edaEntityAbbrev}_stable_id = av.${edaEntityAbbrev}_stable_id
 >templateTextEnd<

--- a/Model/lib/wdk/model/records/geneRecord.xml
+++ b/Model/lib/wdk/model/records/geneRecord.xml
@@ -826,8 +826,8 @@
                  includeProjects="PlasmoDB,UniDB"
                  queryRef="GeneTables.EdaAntibodyArrayGraphsDataTable" >
             <columnAttribute name="dataset_id" displayName="Dataset" internal="true" />
-            <columnAttribute name="variable" displayName="Variable"/>
-            <columnAttribute name="value" displayName="Value"/>
+            <columnAttribute name="sample" displayName="Sample"/>
+            <columnAttribute name="value" displayName="Normalized Intensity"/>
           </table>
 
 

--- a/Model/lib/wdk/model/records/geneTableQueries.xml
+++ b/Model/lib/wdk/model/records/geneTableQueries.xml
@@ -1219,7 +1219,9 @@ from (
                         'xAxisVariableId' VALUE x_axis_variable_id,
                         'yAxisVariableId' VALUE y_axis_variable_id,
                         'displaySpecVariableId' VALUE 'VEUPATHDB_GENE_ID',
-                        'displayMode' VALUE 'highlight',
+                        -- A box plot has no per-point identity to highlight, so
+                        -- the gene must be selected by subsetting instead.
+                        'displayMode' VALUE 'subset',
                         'xMin' VALUE x_min,
                         'xMax' VALUE x_max,
                         'yMin' VALUE y_min,
@@ -4723,22 +4725,20 @@ FROM webready.GeneAttributes_p ga, (
             <column name="source_id"/>
             <column name="project_id"/>
             <column name="dataset_id"/>
-            <column name="variable"/>
+            <column name="sample"/>
             <column name="value"/>
             <sql>
             <![CDATA[
-SELECT ga.source_id, ga.project_id, gd.variable, coalesce(gd.string_value, coalesce(round(gd.number_value::numeric, 4)::text, gd.date_value::text)) AS value, gd.dataset_id
+SELECT ga.source_id, ga.project_id, gd.sample, round(gd.value::numeric, 4)::text AS value, gd.dataset_id
 FROM webready.GeneAttributes_p ga, (
    WITH raw_data as (
        SELECT '' as gene,
-              '' as variable,
-              '' as string_value,
-              0 as number_value,
-              DATE '2000-01-01' as date_value,
+              '' as sample,
+              0 as value,
               'HAPPY_BIRTHDAY' as dataset_id
        -- TEMPLATE_ANCHOR antibodyArrayDataTableGeneTableSql
    )
-   SELECT rd.gene, rd.variable, rd.string_value, rd.number_value, rd.date_value, rd.dataset_id
+   SELECT rd.gene, rd.sample, rd.value, rd.dataset_id
    FROM raw_data rd
 ) gd
    WHERE ga.source_id = gd.gene


### PR DESCRIPTION
Follow-up to #214. Both fixes come from the same cause: the AntibodyArray EDA studies span **two entities** — the measurement sits on the gene entity, its identity and covariates on the parent `sample` entity — while every existing EDA gene graph is single-entity, so nothing had exercised that path.

## `displayMode`: `highlight` → `subset`

`EdaAntibodyArrayDatasets` emitted the literal `'highlight'`. A box plot has no per-point identity to highlight, so the plot was drawn from **every gene's** values rather than the gene whose record page it is. `EdaCellularLocalizationDatasets` already emits `subset`; this uses the same value.

Verified on `PF3D7_1441400` (Loffler): the gene's 33 measurements span 8.60–12.63, while all 48,543 measurements in the study span 0.88–15.62. The plot now draws the former.

## Data table: report the sample, and stop dropping rows

`antibodyArrayDataTableGeneTableSql` joined only the gene entity, so every row was a bare value with no indication of which sample it came from — 450 anonymous intensities for `PF3D7_1441400`. It now joins `eda.ancestors_<study>_<entity>` and reports `sample`, keeping only `NORMALIZED_INTENSITY`; the `Sample` and `Normalized Intensity` columns replace the old `Variable`/`Value` pair.

The template also used `UNION`, which deduplicates identical tuples. Two samples recording the same intensity for one gene collapsed into a single row, and all 33 rows of the constant `Dataset` variable collapsed into one. That is data loss rather than tidying, so this uses `UNION ALL` — which restores the 4 measurements it had been dropping for this gene. The empty seed row remains harmless, filtered out by the join on gene id.

After the change, for `PF3D7_1441400`:

| dataset | rows | distinct samples | min | max |
|---|---|---|---|---|
| Crompton_Mali | 421 | 421 | 4.1455 | 6.6524 |
| Loffler_Natural_Infection | 33 | 33 | 8.6037 | 12.6327 |

Rows equal distinct samples in both, and the Loffler range matches what the box plot draws — table and plot demonstrably read the same measurements.

## Testing

Built on a dev instance (`jbrestel.eupathdb.org`, model `UniDB`) and verified with `wdkQuery -showQuery` plus the rendered SQL run against the appDb. Paired with VEuPathDB/web-monorepo#PENDING, which adds the box plot component the `plot_type` in `EDAGeneGraphs.xls` asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)