### PR TITLE
Migrate FungiDB coexpression questions off Apidb.FungiCoexpression

### DIFF
--- a/Model/lib/wdk/model/questions/queries/geneQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/geneQueries.xml
@@ -5706,13 +5706,15 @@ select distinct ta.gene_source_id
                  , ta.project_id, 'Y' as matched_result
                  , string_agg(ds.gene_source_id, ', ') AS input_id
                  , max(coefficient) as max_coeff, min(coefficient) as min_coeff
-          FROM  apidbtuning.TranscriptAttributes ta, Apidb.FungiCoexpression c,
-                ($$ds_gene_ids$$) ds, apidbtuning.GeneId gi
-  WHERE  gi.gene= ta.gene_source_id
-    AND ( ( c.gene_id = gi.id  AND  c.associated_gene_id = ds.gene_source_id )
-       OR ( c.gene_id = ds.gene_source_id  AND  c.associated_gene_id = gi.id ))
+          FROM  apidbtuning.TranscriptAttributes ta, apidb.genecoexpression c,
+                sres.externaldatabaserelease edr, sres.externaldatabase ed,
+                ($$ds_gene_ids$$) ds
+          WHERE  edr.external_database_release_id = c.external_database_release_id
+    AND  ed.external_database_id = edr.external_database_id
+    AND ( ( c.gene_id = ta.gene_source_id  AND  c.associated_gene_id = ds.gene_source_id )
+       OR ( c.gene_id = ds.gene_source_id  AND  c.associated_gene_id = ta.gene_source_id ))
             AND  c.coefficient $$coexp_correlation$$ $$coexp_value$$
-    AND  c.source=$$coexp_source$$
+    AND  ed.name=$$coexp_source$$
           GROUP BY ta.source_id, ta.gene_source_id, ta.project_id
         ]]>
       </sql>
@@ -5736,13 +5738,14 @@ select distinct ta.gene_source_id
                  ,ta.project_id, 'Y' as matched_result
                  , $$single_gene_id$$ AS input_id
                  , coefficient
-          FROM  apidbtuning.TranscriptAttributes ta, Apidb.FungiCoexpression c,
-                apidbtuning.GeneId gi
+          FROM  apidbtuning.TranscriptAttributes ta, apidb.genecoexpression c,
+                sres.externaldatabaserelease edr, sres.externaldatabase ed
           WHERE  c.gene_id = $$single_gene_id$$
-            AND  c.associated_gene_id = gi.id
-            AND  gi.gene= ta.gene_source_id
+            AND  c.associated_gene_id = ta.gene_source_id
+            AND  edr.external_database_release_id = c.external_database_release_id
+            AND  ed.external_database_id = edr.external_database_id
             AND  c.coefficient $$coexp_network_distance$$
-            AND  c.source='Benz'
+            AND  ed.name='ncraOR74A_Benz_Coexpression_geneCoexpression_RSRC'
         ]]>
       </sql>
     </sqlQuery>

--- a/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/Coexpression.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/Coexpression.java
@@ -30,6 +30,11 @@ public class Coexpression extends  DatasetInjector {
       setPropValue("questionName", "GeneQuestions.GenesByCoexpression" + getDatasetName());
       injectTemplate("internalGeneSearchCategory");
 
+      // apidb.genecoexpression rows are keyed by external_database_release_id, resolved
+      // by joining sres.externaldatabaserelease/externaldatabase on name; the loading
+      // workflow names that row by taking this dataset's own name, dropping "_array_",
+      // and inserting "_geneCoexpression" before the trailing "_RSRC".
+      setPropValue("dataSource", getDatasetName().replace("_array_", "_").replaceFirst("_RSRC$", "_geneCoexpression_RSRC"));
 
       injectTemplate("coexpressionQuestion");
       injectTemplate("coexpressionSourceQuery");
@@ -46,8 +51,7 @@ public class Coexpression extends  DatasetInjector {
 
   @Override
   public String[][] getPropertiesDeclaration() {
-    String [][] propertiesDeclaration = { {"dataSource", "data source in the coexpression table"},
-                                          {"exampleGeneIds", "Gene Ids provided as default on coexpression Q page"},
+    String [][] propertiesDeclaration = { {"exampleGeneIds", "Gene Ids provided as default on coexpression Q page"},
                                           {"defaultCoefficient", "Default value of Spearman Coefficient on Q page"},
     };
 


### PR DESCRIPTION
## Summary
- `Apidb.FungiCoexpression` has been replaced by `apidb.genecoexpression`, which drops the `source` text column in favor of `external_database_release_id` — dataset identity is now resolved by joining `sres.externaldatabaserelease` → `sres.externaldatabase` and matching `ed.name`, the same pattern `GenesBySingleCell` already uses in this same file.
- Migrates the two SQL queries that referenced the old table: `GenesByCoexpression` (generic, shared by the Meyer/Cairns *A. niger* datasets via the `coexp_source` param) and `GenesByNeurosporaCoexpression` (dedicated, Benz dataset — the hardcoded `source='Benz'` literal is now `ed.name='ncraOR74A_Benz_Coexpression_geneCoexpression_RSRC'`).
- Also drops the `apidbtuning.GeneId` bridge join from both queries. The new table's `gene_id`/`associated_gene_id` store gene source IDs directly (confirmed against `genomicsdb_071n`: matches `apidbtuning.TranscriptAttributes.gene_source_id` with full coverage), so the old internal-id translation is no longer needed — simpler than the query it replaces.
- Companion PR in `ApiCommonPresenters` updates the two `dataSource` presenter props (`Meyer`/`Cairns`) to the new long-form `ed.name` values that these queries now filter on: https://github.com/VEuPathDB/ApiCommonPresenters/pull/67

A fourth dataset, Candida/OMeara, has a `GenesByCandidaCoexpression` question — it's already commented out/dead since bld-69, unrelated to this migration (with a pre-existing dangling `addWdkReference` in `OmearaCoexpression.java`). Left as-is; out of scope here.

## Verification
- Rebuilt the model (`wb ontology`) on a dev FungiDB instance — build succeeded, webapp reloaded clean, and the built `geneQueries.xml`/`geneParams.xml` confirm no remaining `FungiCoexpression` references and the correct new literals injected into the per-dataset vocab queries.
- Executed the exact migrated SQL directly against the shared dev DB (`genomicsdb_071n`) for all three live datasets (Neurospora/Benz with `single_gene_id='NCU06929'`, Meyer with `An04g07430`, Cairns with `An02g01255`) — all return correct, non-empty, sane results.
- Confirmed via direct psql that the assumption backing the `GeneId` join removal holds: 100% of a sample dataset's `gene_id`/`associated_gene_id` values match `TranscriptAttributes.gene_source_id`.

## Test plan
- [ ] Re-run the coexpression search questions on a FungiDB dev instance pointed at an environment with `apidb.genecoexpression` loaded, for all 3 live datasets, and confirm result counts/coefficients look sane.
- [ ] Confirm no regression in unrelated `apidbtuning.GeneId`/`ds_gene_ids` consumers elsewhere in `geneQueries.xml`/`pathwayQueries.xml` (untouched by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
