### PR TITLE
Fix disabled injectTemplates() in RNASeqHornRNAi (TriTrypDB)

### DIFF
--- a/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/custom/TriTrypDB/RNASeqHornRNAi.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/custom/TriTrypDB/RNASeqHornRNAi.java
@@ -5,13 +5,14 @@ import org.apidb.apicommon.datasetPresenter.DatasetInjector;
 public class RNASeqHornRNAi extends DatasetInjector {
 
   @Override
-  public void injectTemplates() { }
-  public void TODO_injectTemplates() {
+  public void injectTemplates() {
       setPropValue("datasetClassCategoryIri", "http://edamontology.org/topic_3298");
       setPropValue("includeProjectsExcludeEuPathDB", "TriTrypDB,UniDB");
       setShortAttribution();
       String organismAbbrevDisplay = "T. brucei brucei TREU927"; //getPropValue("organismAbbrevDisplay");
       setPropValue("organismAbbrevDisplay", organismAbbrevDisplay.replace(":", ""));
+
+      setPropValue("cleanDatasetName", getDatasetName().replace('.', '_'));
 
       injectTemplate("datasetCategory");
       injectTemplate("profileSampleAttributesCategory");


### PR DESCRIPTION
## Summary
- Same bug shape as the earlier FungiDB MetaCycle fix: `injectTemplates()` had been renamed to a dead `TODO_injectTemplates()` (never called), while `addModelReferences()` (still active) unconditionally referenced a `profile_graph`, a `GeneRecordClass` table, and the `GenesByHighThroughputPhenotyping` question — all depending on templates only the disabled method would have injected. Fixed by renaming `TODO_injectTemplates()` back to `injectTemplates()`.
- That surfaced the same second, previously-latent bug: this class extends `DatasetInjector` directly (not `RNASeq`), so nothing sets `cleanDatasetName` — and the templates it injects (`profileSampleAttributesCategory`, `profileAttributeQueries`, `profileAttributeRef`, all in `categories.dst`/`profileGraphs.dst`) require it, emitting unresolved `${cleanDatasetName}` macros otherwise. Fixed by setting it explicitly, matching `RNASeq.java`'s own derivation (`datasetName` with `.` replaced by `_`).
- Affects `DS_98fb258539` (`tbruTREU927_RNAi_Horn_rnaSeq_RSRC`).

## Verification
- `wb ontology` rebuild on a fresh TriTrypDB dev instance — build succeeds.
- No unresolved `${cleanDatasetName}` macros in the generated model.
- The generated `ProfileSamplestbruTREU927_RNAi_Horn_rnaSeq_RSRC`/`MetaProfileSamplestbruTREU927...` queries appear correctly in the built model and ontology.
- `GenesByHighThroughputPhenotyping` correctly appears in the category ontology under "Phenomics" (no longer dangling), and its underlying query (`GeneId.GenesByGenericFoldChange`) loads without error via `wdkQuery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
