### PR TITLE
Add JBrowse gene-model tracks for FungiDB ParaDB organisms

### DIFF
--- a/Model/lib/jbrowse/pbraPb03/tracks.conf
+++ b/Model/lib/jbrowse/pbraPb03/tracks.conf
@@ -1,0 +1,15 @@
+[tracks.pbraPb03_pbraPb03_Barbosa_2019_WebService_RSRC]
+category=Gene Models
+metadata.subcategory=Transcripts
+metadata.trackType=Segments
+storeClass=JBrowse/Store/SeqFeature/GFF3Tabix
+topLevelFeatures=gene
+urlTemplate=/a/service/jbrowse/store?data=PbrasiliensisPb03/prealigned/gff/pbraPb03_pbraPb03_Barbosa_2019_WebService_RSRC/pbraPb03_Barbosa_2019.gff.gz
+style.color={processedTranscriptColor}
+type=JBrowse/View/Track/CanvasFeatures
+glyph=JBrowse/View/FeatureGlyph/Box
+style.strandArrow=true
+key=ParaDB P. brasiliensis Pb03 gene models
+metadata.dataset=ParaDB P. brasiliensis Pb03 gene models
+metadata.description=General Description: All data contained in ParaDB was downloaded from GitHub (https://github.com/paracoccidioidesdb).
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName("pbraPb03_pbraPb03_Barbosa_2019_WebService_RSRC", "ParaDB P. brasiliensis Pb03 gene models"); }

--- a/Model/lib/jbrowse/pbraPb18/tracks.conf
+++ b/Model/lib/jbrowse/pbraPb18/tracks.conf
@@ -1,0 +1,15 @@
+[tracks.pbraPb18_pbraPb18_Barbosa_2019_WebService_RSRC]
+category=Gene Models
+metadata.subcategory=Transcripts
+metadata.trackType=Segments
+storeClass=JBrowse/Store/SeqFeature/GFF3Tabix
+topLevelFeatures=gene
+urlTemplate=/a/service/jbrowse/store?data=PbrasiliensisPb18/prealigned/gff/pbraPb18_pbraPb18_Barbosa_2019_WebService_RSRC/pbraPb18_Barbosa_2019.gff.gz
+style.color={processedTranscriptColor}
+type=JBrowse/View/Track/CanvasFeatures
+glyph=JBrowse/View/FeatureGlyph/Box
+style.strandArrow=true
+key=ParaDB P. brasiliensis Pb18 gene models
+metadata.dataset=ParaDB P. brasiliensis Pb18 gene models
+metadata.description=General Description: All data contained in ParaDB was downloaded from GitHub (https://github.com/paracoccidioidesdb).
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName("pbraPb18_pbraPb18_Barbosa_2019_WebService_RSRC", "ParaDB P. brasiliensis Pb18 gene models"); }

--- a/Model/lib/jbrowse/plutPb01/tracks.conf
+++ b/Model/lib/jbrowse/plutPb01/tracks.conf
@@ -1,0 +1,15 @@
+[tracks.plutPb01_plutPb01_ParaDB_WebService_RSRC]
+category=Gene Models
+metadata.subcategory=Transcripts
+metadata.trackType=Segments
+storeClass=JBrowse/Store/SeqFeature/GFF3Tabix
+topLevelFeatures=gene
+urlTemplate=/a/service/jbrowse/store?data=PlutziiPb01/prealigned/gff/plutPb01_plutPb01_ParaDB_WebService_RSRC/plutPb01_ParaDB.gff.gz
+style.color={processedTranscriptColor}
+type=JBrowse/View/Track/CanvasFeatures
+glyph=JBrowse/View/FeatureGlyph/Box
+style.strandArrow=true
+key=Paracoccidioides lutzii Pb01 gene models
+metadata.dataset=Paracoccidioides lutzii Pb01 gene models
+metadata.description=General Description: All data contained in ParaDB was downloaded from GitHub (https://github.com/paracoccidioidesdb).
+fmtMetaValue_Dataset=function() { return datasetLinkByDatasetName("plutPb01_plutPb01_ParaDB_WebService_RSRC", "Paracoccidioides lutzii Pb01 gene models"); }


### PR DESCRIPTION
## Summary
- Adds hand-authored `tracks.conf` gene-model tracks for 3 FungiDB ParaDB organisms (pbraPb03, pbraPb18, plutPb01) that previously had no JBrowse/GBrowse track data at all, so their dataset presenters' genome-browser link was a placeholder `TODO`
- Follows the existing per-organism hand-authored `tracks.conf` convention (e.g. pfal3D7's Hoshizaki lncRNA track) — auto-included by `Model/bin/jbrowseTracks`, no Perl code changes needed
- `topLevelFeatures=gene` excludes each contig's whole-length GFF3 `region` line from rendering as a spurious top-level glyph
- `style.strandArrow=true` shows strand direction arrows (flipped from the inherited `false` default copied from the exemplar track)

## Test plan
- [x] Verified all 3 tracks render correctly on `bindu.fungidb.org` via direct browser check (gene models visible, region glyph gone, strand arrows visible)
- [x] Root-caused and fixed a corrupted `pbraPb18` source GFF3 (plain gzip instead of bgzip) separately, at the data-delivery level — unrelated to this PR's config changes but was blocking verification
- [ ] Still TODO (separate PR, in `ApiCommonPresenters`): update the 3 presenters' `<link><url>` from `TODO` to the real deep-link now that tracks are confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
